### PR TITLE
feat: Theme Toggle (Light / Dark mode)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Switch Tailwind v4 dark: variant to class-based (instead of prefers-color-scheme) */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -17,11 +20,10 @@
   font-family: var(--font-brand), var(--font-geist-sans), system-ui, sans-serif;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+/* Dark-mode CSS custom-property overrides (class-based) */
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {
@@ -44,12 +46,10 @@ body {
   --scrollbar-thumb-hover: #a0a0a0;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --scrollbar-thumb: #555;
-    --scrollbar-track: transparent;
-    --scrollbar-thumb-hover: #777;
-  }
+.dark {
+  --scrollbar-thumb: #555;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb-hover: #777;
 }
 
 /* WebKit browsers (Chrome, Edge, Safari) */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Header from "@/components/Header";
 import { SearchProvider } from "@/components/SpotlightSearch";
 import { TabProvider } from "@/lib/tab-context";
+import { ThemeProvider } from "@/lib/theme-context";
 import { ShortcutHelp } from "@/components/ShortcutHelp";
 import { ToastProvider } from "@/components/Toast";
 
@@ -29,26 +30,35 @@ export const metadata: Metadata = {
     "A platform to help you with development and day-to-day corporate work.",
 };
 
+// Inline script to apply the saved theme BEFORE React hydrates, preventing
+// a flash of the wrong theme. Runs synchronously in <head>.
+const themeScript = `(function(){try{var t=localStorage.getItem('toolich-theme');if(t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} antialiased`}
         suppressHydrationWarning
       >
-        <TabProvider>
-          <SearchProvider>
-            <ToastProvider>
-              <Header />
-              {children}
-              <ShortcutHelp />
-            </ToastProvider>
-          </SearchProvider>
-        </TabProvider>
+        <ThemeProvider>
+          <TabProvider>
+            <SearchProvider>
+              <ToastProvider>
+                <Header />
+                {children}
+                <ShortcutHelp />
+              </ToastProvider>
+            </SearchProvider>
+          </TabProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { SearchTrigger, SearchModal } from "./SpotlightSearch";
+import { ThemeToggle } from "./ThemeToggle";
 
 type HeaderProps = {
   githubUrl?: string;
@@ -38,6 +39,9 @@ export default function Header({
           <div className="flex items-center gap-3">
             {/* Search trigger */}
             <SearchTrigger />
+
+            {/* Theme toggle */}
+            <ThemeToggle />
 
             {/* GitHub link */}
             <a

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/lib/theme-context";
+
+export function ThemeToggle() {
+    const { resolvedTheme, toggleTheme } = useTheme();
+    const isDark = resolvedTheme === "dark";
+
+    return (
+        <button
+            type="button"
+            onClick={toggleTheme}
+            className="relative flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-600 shadow-sm transition-all hover:border-zinc-300 hover:text-zinc-900 active:scale-95 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-100"
+            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            title={isDark ? "Light mode" : "Dark mode"}
+        >
+            {isDark ? (
+                <Sun className="h-4 w-4" />
+            ) : (
+                <Moon className="h-4 w-4" />
+            )}
+        </button>
+    );
+}

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+    createContext,
+    useContext,
+    useEffect,
+    useState,
+    useCallback,
+    type ReactNode,
+} from "react";
+
+type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+type ThemeContextValue = {
+    theme: Theme;
+    resolvedTheme: ResolvedTheme;
+    setTheme: (t: Theme) => void;
+    toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "toolich-theme";
+
+function getSystemPreference(): ResolvedTheme {
+    if (typeof window === "undefined") return "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+}
+
+function applyClass(resolved: ResolvedTheme) {
+    const root = document.documentElement;
+    if (resolved === "dark") {
+        root.classList.add("dark");
+    } else {
+        root.classList.remove("dark");
+    }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+    const [theme, setThemeRaw] = useState<Theme>("system");
+    const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
+    const [mounted, setMounted] = useState(false);
+
+    // On first mount, read localStorage and apply
+    useEffect(() => {
+        const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+        const chosen: Theme = stored === "light" || stored === "dark" ? stored : "system";
+        const resolved: ResolvedTheme = chosen === "system" ? getSystemPreference() : chosen;
+
+        setThemeRaw(chosen);
+        setResolvedTheme(resolved);
+        applyClass(resolved);
+        setMounted(true);
+    }, []);
+
+    // Listen for OS theme changes when mode = "system"
+    useEffect(() => {
+        if (!mounted || theme !== "system") return;
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const handler = () => {
+            const next = getSystemPreference();
+            setResolvedTheme(next);
+            applyClass(next);
+        };
+        mq.addEventListener("change", handler);
+        return () => mq.removeEventListener("change", handler);
+    }, [mounted, theme]);
+
+    const setTheme = useCallback((t: Theme) => {
+        const resolved: ResolvedTheme = t === "system" ? getSystemPreference() : t;
+        setThemeRaw(t);
+        setResolvedTheme(resolved);
+        applyClass(resolved);
+        localStorage.setItem(STORAGE_KEY, t);
+    }, []);
+
+    const toggleTheme = useCallback(() => {
+        const next: ResolvedTheme = resolvedTheme === "dark" ? "light" : "dark";
+        setTheme(next);
+    }, [resolvedTheme, setTheme]);
+
+    return (
+        <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme(): ThemeContextValue {
+    const ctx = useContext(ThemeContext);
+    if (!ctx) throw new Error("useTheme must be used within <ThemeProvider>");
+    return ctx;
+}


### PR DESCRIPTION
## Summary
- Adds a light/dark theme toggle button (Sun/Moon icon) to the header
- Implements a `ThemeProvider` context with localStorage persistence and system-preference fallback
- Switches Tailwind dark variant to class-based (`.dark`) to prevent FOUC with an inline `<head>` script

Closes #44

## Test plan
- [x] Click the toggle and verify instant switch between light and dark mode
- [x] Reload the page and confirm the chosen theme persists
- [x] Clear localStorage and verify it falls back to OS preference
- [x] Change OS theme while set to "system" and confirm it reacts
- [x] Verify no flash of wrong theme on fresh page load