### PR TITLE
feat: add Progressive Web App (PWA) support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  headers: async () => [
+    {
+      source: "/sw.js",
+      headers: [
+        {
+          key: "Service-Worker-Allowed",
+          value: "/",
+        },
+        {
+          key: "Cache-Control",
+          value: "no-cache, no-store, must-revalidate",
+        },
+      ],
+    },
+  ],
 };
 
 export default nextConfig;

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="38" fill="#6366f1"/>
+  <path d="M48 58h96v19H48V58zm38 19v58h20V77h-20z" fill="white" fill-opacity="0.95"/>
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="102" fill="#6366f1"/>
+  <path d="M128 154h256v50H128v-50zm102 50v154h52V204h-52z" fill="white" fill-opacity="0.95"/>
+</svg>

--- a/public/icon-maskable.svg
+++ b/public/icon-maskable.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" fill="#6366f1"/>
+  <path d="M128 154h256v50H128v-50zm102 50v154h52V204h-52z" fill="white" fill-opacity="0.95"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,32 @@
+{
+  "name": "Toolich — Developer Tools",
+  "short_name": "Toolich",
+  "description": "A platform to help you with development and day-to-day corporate work.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#09090b",
+  "theme_color": "#6366f1",
+  "orientation": "any",
+  "categories": ["developer", "utilities", "productivity"],
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------
+// Toolich Service Worker — offline-capable PWA
+// ---------------------------------------------------------------------------
+
+const CACHE_VERSION = "toolich-v1";
+const STATIC_CACHE = `${CACHE_VERSION}-static`;
+const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
+
+// Assets to pre-cache on install (app shell)
+const PRE_CACHE = ["/", "/offline"];
+
+// ---------------------------------------------------------------------------
+// Install — pre-cache app shell
+// ---------------------------------------------------------------------------
+self.addEventListener("install", (event) => {
+    event.waitUntil(
+        caches
+            .open(STATIC_CACHE)
+            .then((cache) => cache.addAll(PRE_CACHE))
+            .then(() => self.skipWaiting()),
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Activate — clean old caches
+// ---------------------------------------------------------------------------
+self.addEventListener("activate", (event) => {
+    event.waitUntil(
+        caches
+            .keys()
+            .then((keys) =>
+                Promise.all(
+                    keys
+                        .filter((k) => k !== STATIC_CACHE && k !== RUNTIME_CACHE)
+                        .map((k) => caches.delete(k)),
+                ),
+            )
+            .then(() => self.clients.claim()),
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Fetch — stale-while-revalidate for pages, cache-first for static assets
+// ---------------------------------------------------------------------------
+self.addEventListener("fetch", (event) => {
+    const { request } = event;
+
+    // Skip non-GET and chrome-extension requests
+    if (request.method !== "GET" || !request.url.startsWith("http")) return;
+
+    const url = new URL(request.url);
+
+    // Static assets — cache-first
+    if (
+        url.pathname.match(
+            /\.(js|css|svg|png|jpg|jpeg|webp|woff2?|ttf|ico|json)$/,
+        ) &&
+        !url.pathname.endsWith("manifest.json")
+    ) {
+        event.respondWith(
+            caches.match(request).then(
+                (cached) =>
+                    cached ||
+                    fetch(request).then((response) => {
+                        if (response.ok) {
+                            const clone = response.clone();
+                            caches
+                                .open(RUNTIME_CACHE)
+                                .then((cache) => cache.put(request, clone));
+                        }
+                        return response;
+                    }),
+            ),
+        );
+        return;
+    }
+
+    // HTML pages — network-first, fallback to cache
+    if (request.headers.get("accept")?.includes("text/html")) {
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.ok) {
+                        const clone = response.clone();
+                        caches
+                            .open(RUNTIME_CACHE)
+                            .then((cache) => cache.put(request, clone));
+                    }
+                    return response;
+                })
+                .catch(() => caches.match(request).then((cached) => cached || caches.match("/"))),
+        );
+        return;
+    }
+
+    // Everything else — network-first
+    event.respondWith(
+        fetch(request).catch(() => caches.match(request)),
+    );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,9 @@ export const metadata: Metadata = {
 // a flash of the wrong theme. Runs synchronously in <head>.
 const themeScript = `(function(){try{var t=localStorage.getItem('toolich-theme');if(t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()`;
 
+// Register service worker for PWA support
+const swScript = `if('serviceWorker' in navigator){window.addEventListener('load',function(){navigator.serviceWorker.register('/sw.js')})}`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -43,6 +46,12 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#6366f1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <link rel="apple-touch-icon" href="/icon-192.svg" />
+        <script dangerouslySetInnerHTML={{ __html: swScript }} />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} antialiased`}


### PR DESCRIPTION
Closes #60

## Summary
- Add `manifest.json` with app metadata, theme color, and SVG icons (192px, 512px, maskable)
- Register a service worker (`sw.js`) with network-first caching strategy
- Configure `next.config.ts` with proper `Service-Worker-Allowed` and cache-control headers
- Add PWA meta tags and Apple mobile web app support in the root layout

## Test plan
- [x] Verify the app is installable via the browser install prompt
- [x] Check that `/manifest.json` loads correctly with proper icon paths
- [x] Confirm service worker registers and caches pages on subsequent visits
- [x] Test on iOS Safari for Apple touch icon and standalone mode

