### PR TITLE
feat: add JSON to Schema tool

### DIFF
--- a/src/app/tools/developers/json-to-schema/page.tsx
+++ b/src/app/tools/developers/json-to-schema/page.tsx
@@ -1,0 +1,21 @@
+import { ToolPageHeader } from "@/components/ToolPageHeader";
+import JsonToSchema from "@/tools/developers/json-to-schema/JsonToSchema";
+import { toolMeta } from "@/tools/developers/json-to-schema";
+
+export const metadata = {
+    title: `${toolMeta.name} | Toolich`,
+    description: toolMeta.description,
+};
+
+export default function JsonToSchemaPage() {
+    return (
+        <>
+            <ToolPageHeader
+                toolName={toolMeta.name}
+                description={toolMeta.description}
+                category={toolMeta.category}
+            />
+            <JsonToSchema />
+        </>
+    );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
             base64Decode: "/tools/developers/base64-decode",
             jsonFormatter: "/tools/developers/json-formatter",
             uuidGenerator: "/tools/developers/uuid-generator",
+            jsonToSchema: "/tools/developers/json-to-schema",
         },
         security: {
             hashGenerator: "/tools/security/hash-generator",

--- a/src/lib/tool-components.ts
+++ b/src/lib/tool-components.ts
@@ -5,6 +5,7 @@ import Base64Encoder from "@/tools/developers/base64-encode/Base64Encoder";
 import Base64Decoder from "@/tools/developers/base64-decode/Base64Decoder";
 import JsonFormatter from "@/tools/developers/json-formatter/JsonFormatter";
 import UuidGenerator from "@/tools/developers/uuid-generator/UuidGenerator";
+import JsonToSchema from "@/tools/developers/json-to-schema/JsonToSchema";
 import HashGenerator from "@/tools/security/hash-generator/HashGenerator";
 import PasswordGenerator from "@/tools/security/password-generator/PasswordGenerator";
 import CronParser from "@/tools/devops/cron-parser/CronParser";
@@ -24,6 +25,7 @@ const TOOL_COMPONENTS: Record<string, ComponentType> = {
     "developers/base64-decode": Base64Decoder,
     "developers/json-formatter": JsonFormatter,
     "developers/uuid-generator": UuidGenerator,
+    "developers/json-to-schema": JsonToSchema,
     "security/hash-generator": HashGenerator,
     "security/password-generator": PasswordGenerator,
     "devops/cron-parser": CronParser,

--- a/src/lib/tool-registry.ts
+++ b/src/lib/tool-registry.ts
@@ -51,6 +51,18 @@ const TOOLS: ToolMeta[] = [
         keywords: ["base64", "decode", "convert", "binary"],
     },
     {
+        name: "JSON to Schema",
+        slug: "json-to-schema",
+        description:
+            "Infer a JSON Schema (draft-07) from any JSON object or array input.",
+        category: "developers",
+        keywords: [
+            "json", "schema", "json schema", "json to schema",
+            "infer", "generate", "draft-07", "validator",
+            "convert", "structure", "type",
+        ],
+    },
+    {
         name: "JSON Formatter",
         slug: "json-formatter",
         description: "Format, prettify, and minify JSON with validation.",

--- a/src/tools/developers/json-to-schema/JsonToSchema.tsx
+++ b/src/tools/developers/json-to-schema/JsonToSchema.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Copy, Check, Trash2, ArrowRight, AlertCircle } from "lucide-react";
+import { useSessionState } from "@/lib/use-session-state";
+import { inferSchema } from "./schema-inferrer";
+
+const DEFAULT_SAMPLE = JSON.stringify(
+    {
+        id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+        name: "Toolich",
+        version: "1.0.0",
+        active: true,
+        tags: ["developer", "tools", "productivity"],
+    },
+    null,
+    2,
+);
+
+export default function JsonToSchema() {
+    // ---- persisted state ----
+    const [input, setInput] = useSessionState("j2s:input", DEFAULT_SAMPLE);
+
+    // ---- transient state ----
+    const [copied, setCopied] = useState(false);
+
+    // ---- inference ----
+    const { schema, error } = useMemo(() => {
+        const trimmed = input.trim();
+        if (!trimmed) return { schema: "", error: "" };
+
+        try {
+            const parsed = JSON.parse(trimmed);
+            const result = inferSchema(parsed);
+            return {
+                schema: JSON.stringify(result, null, 2),
+                error: "",
+            };
+        } catch (e) {
+            return {
+                schema: "",
+                error: e instanceof Error ? e.message : "Invalid JSON",
+            };
+        }
+    }, [input]);
+
+    // ---- actions ----
+    const handleCopy = async () => {
+        if (!schema) return;
+        await navigator.clipboard.writeText(schema);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    };
+
+    const handleClear = () => {
+        setInput("");
+    };
+
+    const handleSample = () => {
+        setInput(
+            JSON.stringify(
+                {
+                    id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+                    name: "Toolich",
+                    version: "1.0.0",
+                    active: true,
+                    tags: ["developer", "tools", "productivity"],
+                },
+            ),
+        );
+    };
+
+    return (
+        <div className="space-y-6">
+            {/* ── Input / Output split ── */}
+            <div className="grid gap-6 lg:grid-cols-2">
+                {/* LEFT — JSON Input */}
+                <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                        <label className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                            JSON Input
+                        </label>
+                        {!input.trim() && (
+                            <button
+                                type="button"
+                                onClick={handleSample}
+                                className="inline-flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-medium text-zinc-500 transition-all hover:border-indigo-300 hover:text-indigo-600 active:scale-[0.97] dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:border-indigo-600/50 dark:hover:text-indigo-400"
+                            >
+                                Load Sample
+                            </button>
+                        )}
+                    </div>
+                    <textarea
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        placeholder='{\n  "name": "example",\n  "value": 42\n}'
+                        rows={20}
+                        spellCheck={false}
+                        className="w-full resize-y rounded-xl border border-zinc-200 bg-white p-4 font-mono text-sm leading-relaxed text-zinc-900 shadow-sm outline-none transition-colors placeholder:text-zinc-400 focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:border-indigo-500"
+                    />
+                    {/* Error */}
+                    {error && (
+                        <div className="flex items-start gap-2 rounded-lg bg-red-50 px-3 py-2 dark:bg-red-500/10">
+                            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-500" />
+                            <p className="text-xs font-medium text-red-600 dark:text-red-400">
+                                {error}
+                            </p>
+                        </div>
+                    )}
+                </div>
+
+                {/* RIGHT — Schema Output */}
+                <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                        <label className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                            Generated JSON Schema
+                        </label>
+                        {schema && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400">
+                                <ArrowRight className="h-3 w-3" />
+                                draft-07
+                            </span>
+                        )}
+                    </div>
+                    <div className="relative">
+                        <textarea
+                            value={schema}
+                            readOnly
+                            placeholder="Schema will appear here…"
+                            rows={20}
+                            spellCheck={false}
+                            className="w-full resize-y rounded-xl border border-zinc-200 bg-zinc-50 p-4 font-mono text-sm leading-relaxed text-zinc-900 shadow-sm outline-none dark:border-zinc-700 dark:bg-zinc-900/40 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            {/* ── Actions ── */}
+            <div className="flex flex-wrap items-center gap-3">
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    disabled={!schema}
+                    className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-300 hover:bg-zinc-50 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-600 dark:hover:bg-zinc-700"
+                >
+                    {copied ? (
+                        <>
+                            <Check className="h-4 w-4 text-emerald-500" /> Copied!
+                        </>
+                    ) : (
+                        <>
+                            <Copy className="h-4 w-4" /> Copy Schema
+                        </>
+                    )}
+                </button>
+
+                <button
+                    type="button"
+                    onClick={handleClear}
+                    disabled={!input}
+                    className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm transition-all hover:border-zinc-300 hover:bg-zinc-50 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-600 dark:hover:bg-zinc-700"
+                >
+                    <Trash2 className="h-4 w-4" /> Clear
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/tools/developers/json-to-schema/index.ts
+++ b/src/tools/developers/json-to-schema/index.ts
@@ -1,0 +1,14 @@
+import type { ToolMeta } from "@/lib/tool-registry";
+
+export const toolMeta: ToolMeta = {
+    name: "JSON to Schema",
+    slug: "json-to-schema",
+    description:
+        "Infer a JSON Schema (draft-07) from any JSON object or array input.",
+    category: "developers",
+    keywords: [
+        "json", "schema", "json schema", "json to schema",
+        "infer", "generate", "draft-07", "validator",
+        "convert", "structure", "type",
+    ],
+};

--- a/src/tools/developers/json-to-schema/schema-inferrer.ts
+++ b/src/tools/developers/json-to-schema/schema-inferrer.ts
@@ -1,0 +1,230 @@
+// ---------------------------------------------------------------------------
+// JSON → JSON Schema (draft-07) inference engine
+// ---------------------------------------------------------------------------
+
+export type JsonSchemaNode = {
+    type?: string | string[];
+    properties?: Record<string, JsonSchemaNode>;
+    items?: JsonSchemaNode;
+    required?: string[];
+    enum?: unknown[];
+    format?: string;
+    description?: string;
+    $schema?: string;
+    // primitives
+    minLength?: number;
+    pattern?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Main entry — accepts any parsed JSON value
+// ---------------------------------------------------------------------------
+
+export function inferSchema(value: unknown): JsonSchemaNode {
+    const schema = infer(value);
+    return { $schema: "http://json-schema.org/draft-07/schema#", ...schema };
+}
+
+// ---------------------------------------------------------------------------
+// Internal recursive inference
+// ---------------------------------------------------------------------------
+
+function infer(value: unknown): JsonSchemaNode {
+    if (value === null) {
+        return { type: "null" };
+    }
+
+    switch (typeof value) {
+        case "string":
+            return inferString(value);
+        case "number":
+            return Number.isInteger(value) ? { type: "integer" } : { type: "number" };
+        case "boolean":
+            return { type: "boolean" };
+        case "object":
+            if (Array.isArray(value)) {
+                return inferArray(value);
+            }
+            return inferObject(value as Record<string, unknown>);
+        default:
+            return {};
+    }
+}
+
+// ---------------------------------------------------------------------------
+// String format detection
+// ---------------------------------------------------------------------------
+
+function inferString(value: string): JsonSchemaNode {
+    const node: JsonSchemaNode = { type: "string" };
+
+    // date-time: ISO 8601
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(value)) {
+        node.format = "date-time";
+        return node;
+    }
+    // date
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        node.format = "date";
+        return node;
+    }
+    // time
+    if (/^\d{2}:\d{2}:\d{2}/.test(value)) {
+        node.format = "time";
+        return node;
+    }
+    // email
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+        node.format = "email";
+        return node;
+    }
+    // URI
+    if (/^https?:\/\/.+/.test(value)) {
+        node.format = "uri";
+        return node;
+    }
+    // UUID
+    if (
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+            value,
+        )
+    ) {
+        node.format = "uuid";
+        return node;
+    }
+    // IPv4
+    if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(value)) {
+        node.format = "ipv4";
+        return node;
+    }
+
+    return node;
+}
+
+// ---------------------------------------------------------------------------
+// Object inference — generate properties + required[]
+// ---------------------------------------------------------------------------
+
+function inferObject(obj: Record<string, unknown>): JsonSchemaNode {
+    const properties: Record<string, JsonSchemaNode> = {};
+    const required: string[] = [];
+
+    for (const [key, val] of Object.entries(obj)) {
+        properties[key] = infer(val);
+        // Mark all keys as required (single-sample inference)
+        required.push(key);
+    }
+
+    const node: JsonSchemaNode = { type: "object", properties };
+    if (required.length > 0) {
+        node.required = required;
+    }
+    return node;
+}
+
+// ---------------------------------------------------------------------------
+// Array inference — merge element schemas into a single `items`
+// ---------------------------------------------------------------------------
+
+function inferArray(arr: unknown[]): JsonSchemaNode {
+    if (arr.length === 0) {
+        return { type: "array", items: {} };
+    }
+
+    // Infer schema for each element
+    const elementSchemas = arr.map(infer);
+
+    // If all elements produce the same type, merge properties
+    const merged = mergeSchemas(elementSchemas);
+    return { type: "array", items: merged };
+}
+
+// ---------------------------------------------------------------------------
+// Merge multiple schemas (for array element unification)
+// ---------------------------------------------------------------------------
+
+function mergeSchemas(schemas: JsonSchemaNode[]): JsonSchemaNode {
+    if (schemas.length === 0) return {};
+    if (schemas.length === 1) return schemas[0];
+
+    // Collect all types
+    const typeSet = new Set<string>();
+    for (const s of schemas) {
+        if (s.type) {
+            if (Array.isArray(s.type)) {
+                s.type.forEach((t) => typeSet.add(t));
+            } else {
+                typeSet.add(s.type);
+            }
+        }
+    }
+
+    // If all same type, merge deeper
+    if (typeSet.size === 1) {
+        const singleType = [...typeSet][0];
+
+        if (singleType === "object") {
+            return mergeObjectSchemas(schemas);
+        }
+
+        if (singleType === "array") {
+            // Merge all items schemas
+            const itemSchemas = schemas
+                .map((s) => s.items)
+                .filter((i): i is JsonSchemaNode => !!i);
+            return {
+                type: "array",
+                items: itemSchemas.length > 0 ? mergeSchemas(itemSchemas) : {},
+            };
+        }
+
+        // Primitives — just return the first (they all share the same type)
+        return schemas[0];
+    }
+
+    // Mixed types — use type array
+    // Simplify integer + number → number
+    if (typeSet.has("integer") && typeSet.has("number")) {
+        typeSet.delete("integer");
+    }
+    const types = [...typeSet];
+    if (types.length === 1) {
+        return { type: types[0] };
+    }
+    return { type: types };
+}
+
+// ---------------------------------------------------------------------------
+// Merge multiple object schemas (union of properties)
+// ---------------------------------------------------------------------------
+
+function mergeObjectSchemas(schemas: JsonSchemaNode[]): JsonSchemaNode {
+    const allProps: Record<string, JsonSchemaNode[]> = {};
+    const allKeys = new Set<string>();
+    const keyCounts: Record<string, number> = {};
+
+    for (const s of schemas) {
+        if (s.properties) {
+            for (const [key, val] of Object.entries(s.properties)) {
+                allKeys.add(key);
+                if (!allProps[key]) allProps[key] = [];
+                allProps[key].push(val);
+                keyCounts[key] = (keyCounts[key] || 0) + 1;
+            }
+        }
+    }
+
+    const properties: Record<string, JsonSchemaNode> = {};
+    for (const key of allKeys) {
+        properties[key] = mergeSchemas(allProps[key]);
+    }
+
+    // Only mark as required if key appears in ALL schemas
+    const required = [...allKeys].filter((k) => keyCounts[k] === schemas.length);
+
+    const node: JsonSchemaNode = { type: "object", properties };
+    if (required.length > 0) {
+        node.required = required;
+    }
+    return node;
+}


### PR DESCRIPTION
Closes #7

## Summary
- Add JSON to Schema tool that infers a JSON Schema (draft-07) from any JSON object or array input
- Handles nested objects, arrays, and primitive types with proper schema generation
- Register tool in routes, tool components, and tool registry
- Add standalone page at `/tools/developers/json-to-schema`

## Test plan
- [x] Verify the tool page loads at `/tools/developers/json-to-schema`
- [x] Paste a JSON object and confirm a valid draft-07 schema is generated
- [x] Test with deeply nested structures and mixed-type arrays
- [x] Confirm copy-to-clipboard and clear actions work
- [x] Verify the tool appears under the Developers category on the dashboard
