### PR TITLE
feat(markdown-editor): add split-pane editor with live preview and Mermaid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "cronstrue": "^3.13.0",
         "hash-wasm": "^4.12.0",
         "lucide-react": "^0.563.0",
+        "marked": "^18.0.5",
+        "mermaid": "^11.15.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -38,6 +40,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -280,6 +295,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -507,6 +534,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1025,6 +1069,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1528,11 +1581,270 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1578,6 +1890,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -2117,6 +2436,16 @@
         "win32"
       ]
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2600,6 +2929,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2613,6 +2951,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -2656,6 +3003,505 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2718,6 +3564,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2779,6 +3631,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2800,6 +3661,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3021,6 +3891,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3804,6 +4684,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3921,6 +4807,18 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3948,6 +4846,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3971,6 +4879,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4513,6 +5430,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4522,6 +5464,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -4542,6 +5489,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4834,6 +5787,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4892,6 +5851,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4910,6 +5881,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/micromatch": {
@@ -5276,6 +6288,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5288,6 +6306,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5333,6 +6357,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5551,6 +6591,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5574,6 +6632,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -5629,6 +6693,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6041,6 +7111,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6086,6 +7162,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -6160,6 +7245,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6423,6 +7517,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cronstrue": "^3.13.0",
     "hash-wasm": "^4.12.0",
     "lucide-react": "^0.563.0",
+    "marked": "^18.0.5",
+    "mermaid": "^11.15.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/app/tools/manager/markdown-editor/page.tsx
+++ b/src/app/tools/manager/markdown-editor/page.tsx
@@ -1,0 +1,21 @@
+import { ToolPageHeader } from "@/components/ToolPageHeader";
+import MarkdownEditor from "@/tools/managers/markdown-editor/MarkdownEditor";
+import { toolMeta } from "@/tools/managers/markdown-editor";
+
+export const metadata = {
+    title: `${toolMeta.name} | Toolich`,
+    description: toolMeta.description,
+};
+
+export default function MarkdownEditorPageSingular() {
+    return (
+        <>
+            <ToolPageHeader
+                toolName={toolMeta.name}
+                description={toolMeta.description}
+                category="manager"
+            />
+            <MarkdownEditor />
+        </>
+    );
+}

--- a/src/app/tools/managers/markdown-editor/page.tsx
+++ b/src/app/tools/managers/markdown-editor/page.tsx
@@ -1,0 +1,21 @@
+import { ToolPageHeader } from "@/components/ToolPageHeader";
+import MarkdownEditor from "@/tools/managers/markdown-editor/MarkdownEditor";
+import { toolMeta } from "@/tools/managers/markdown-editor";
+
+export const metadata = {
+    title: `${toolMeta.name} | Toolich`,
+    description: toolMeta.description,
+};
+
+export default function MarkdownEditorPage() {
+    return (
+        <>
+            <ToolPageHeader
+                toolName={toolMeta.name}
+                description={toolMeta.description}
+                category={toolMeta.category}
+            />
+            <MarkdownEditor />
+        </>
+    );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -35,6 +35,7 @@ export const ROUTES = {
         },
         managers: {
             diffChecker: "/tools/managers/diff-checker",
+            markdownEditor: "/tools/managers/markdown-editor",
         },
     },
 } as const;

--- a/src/lib/tool-components.ts
+++ b/src/lib/tool-components.ts
@@ -14,6 +14,7 @@ import RegexTester from "@/tools/devops/regex-tester/RegexTester";
 import SubnetCalculator from "@/tools/networking/subnet-calculator/SubnetCalculator";
 import DiffChecker from "@/tools/managers/diff-checker/DiffChecker";
 import DnsLookup from "@/tools/networking/dns-lookup/DnsLookup";
+import MarkdownEditor from "@/tools/managers/markdown-editor/MarkdownEditor";
 
 /**
  * Registry of tool components.
@@ -35,6 +36,8 @@ const TOOL_COMPONENTS: Record<string, ComponentType> = {
     "networking/subnet-calculator": SubnetCalculator,
     "networking/dns-lookup": DnsLookup,
     "managers/diff-checker": DiffChecker,
+    "managers/markdown-editor": MarkdownEditor,
+    "manager/markdown-editor": MarkdownEditor,
 };
 
 /**

--- a/src/lib/tool-registry.ts
+++ b/src/lib/tool-registry.ts
@@ -164,6 +164,16 @@ const TOOLS: ToolMeta[] = [
             "ttl", "network", "networking",
         ],
     },
+    {
+        name: "Markdown Editor",
+        slug: "markdown-editor",
+        description: "Write and preview Markdown in a split-pane editor with live rendering.",
+        category: "managers",
+        keywords: [
+            "markdown", "editor", "preview", "gfm", "commonmark", "writer",
+            "wysiwyg", "mermaid", "diagram", "graph", "chart",
+        ],
+    },
 ];
 
 // ---------------------------------------------------------------------------
@@ -188,7 +198,8 @@ export function getToolBySlug(
     category: string,
     slug: string,
 ): ToolMetaWithPath | undefined {
-    return allTools.find((t) => t.category === category && t.slug === slug);
+    const normCategory = category === "manager" ? "managers" : category;
+    return allTools.find((t) => t.category === normCategory && t.slug === slug);
 }
 
 /** Search tools by query (matches name, description, keywords) */

--- a/src/tools/managers/markdown-editor/MarkdownEditor.tsx
+++ b/src/tools/managers/markdown-editor/MarkdownEditor.tsx
@@ -1,0 +1,1124 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { marked } from "marked";
+import { 
+    Bold, Italic, Heading, Link, Image, Code, List, ListOrdered, CheckSquare, 
+    FileText, Copy, Trash2, Eye, Edit3, Columns, ArrowDownToLine, Check, HelpCircle,
+    Printer
+} from "lucide-react";
+
+// Default markdown content showing off features
+const DEFAULT_MARKDOWN = `# 📝 Advanced Markdown Editor & Preview
+
+Welcome to the **Toolich Markdown Editor**! This is a state-of-the-art editor that features:
+
+* **Live Split-pane Preview** (Responsive stack on mobile)
+* **Real-time Syntax Highlighting** in the editor
+* **Mermaid.js Graphs & Flowcharts**
+* **Interactive Checklist Toggles**
+* **HTML & Raw Markdown Export**
+
+---
+
+## 📊 Live Graphs (Mermaid)
+
+You can write charts and graphs natively using \` \` \`mermaid\` (without spaces) code blocks:
+
+\`\`\`mermaid
+graph TD
+    A[Write Markdown] --> B(Live Preview)
+    B --> C{Render Graphs?}
+    C -->|Yes| D[Beautiful SVGs]
+    C -->|No| E[Plain Text Code]
+\`\`\`
+
+Or sequence diagrams:
+
+\`\`\`mermaid
+sequenceDiagram
+    Alice->>Bob: Hello Bob, how are you?
+    Bob-->>Alice: Great, thanks!
+\`\`\`
+
+---
+
+## 📋 Task Lists (Try clicking checkboxes in preview!)
+
+- [x] Create a premium Markdown Editor
+- [x] Add syntax highlighting
+- [ ] Write some documentation
+- [ ] Export to HTML
+
+---
+
+## 📐 Formatting & GFM Features
+
+### Strikethrough
+
+This is a ~~strikethrough text~~.
+
+### Blockquotes
+
+> "The advance tool this should be." - Master Yoda
+
+### Tables
+
+| Feature | Support | Performance |
+| :--- | :---: | ---: |
+| Split View | Yes | 60 FPS |
+| Mermaid Diagrams | Yes | Dynamic |
+| Export HTML | Yes | Instant |
+
+---
+
+## 💻 Code Highlighting
+
+Here is some inline code like \`const x = 42;\`. And here is a fenced JS block:
+
+\`\`\`javascript
+function greet(name) {
+    console.log(\`Hello, \${name}!\`);
+}
+greet("World");
+\`\`\`
+`;
+
+// Helper to highlight Markdown syntax in the editor
+function highlightMarkdown(text: string): string {
+    // 1. Escape HTML first
+    let html = text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
+    // 2. Process line-by-line block elements
+    const lines = html.split("\n");
+    const highlightedLines = lines.map((line) => {
+        // Headings (# Header)
+        if (/^(#{1,6})\s+(.*)$/.test(line)) {
+            return line.replace(/^(#{1,6})\s+(.*)$/, (match, hashes, content) => {
+                return `<span class="text-indigo-600 dark:text-indigo-400 font-bold">${hashes} ${content}</span>`;
+            });
+        }
+        // Blockquotes (> quote)
+        if (/^\s*&gt;\s+(.*)$/.test(line)) {
+            return line.replace(/^(\s*&gt;\s+)(.*)$/, (match, prefix, content) => {
+                return `<span class="text-emerald-600 dark:text-emerald-500 italic font-medium">${prefix}${content}</span>`;
+            });
+        }
+        // Horizontal rule
+        if (/^\s*[-*_]{3,}\s*$/.test(line)) {
+            return `<span class="text-zinc-400 dark:text-zinc-600 font-bold">${line}</span>`;
+        }
+        // Unordered and task list items
+        if (/^\s*([-*+])\s+(.*)$/.test(line)) {
+            return line.replace(/^(\s*[-*+]\s+)(.*)$/, (match, prefix, content) => {
+                if (content.startsWith("[ ]") || content.startsWith("[x]") || content.startsWith("[X]")) {
+                    const box = content.substring(0, 3);
+                    const rest = content.substring(3);
+                    return `<span class="text-amber-600 dark:text-amber-500 font-bold">${prefix}</span> <span class="text-indigo-500 dark:text-indigo-400 font-mono font-bold">${box}</span>${rest}`;
+                }
+                return `<span class="text-amber-600 dark:text-amber-500 font-bold">${prefix}</span> ${content}`;
+            });
+        }
+        // Ordered list items
+        if (/^\s*(\d+\.)\s+(.*)$/.test(line)) {
+            return line.replace(/^(\s*\d+\.\s+)(.*)$/, (match, prefix, content) => {
+                return `<span class="text-amber-600 dark:text-amber-500 font-bold">${prefix}</span> ${content}`;
+            });
+        }
+        return line;
+    });
+
+    html = highlightedLines.join("\n");
+
+    // 3. Fenced Code Blocks (```lang ... ```)
+    html = html.replace(/(```[a-zA-Z0-9-]*\n[\s\S]*?\n```)/g, (match) => {
+        return `<span class="text-zinc-500 dark:text-zinc-400 font-mono">${match}</span>`;
+    });
+
+    // 4. Inline code (`code`)
+    html = html.replace(/(`[^`\n]+`)/g, (match) => {
+        return `<span class="bg-zinc-100 dark:bg-zinc-800 text-rose-600 dark:text-rose-400 font-mono rounded px-1.5 py-0.5 border border-zinc-200 dark:border-zinc-800 text-[12px]">${match}</span>`;
+    });
+
+    // 5. Images (![alt](url))
+    html = html.replace(/(!\[[^\]]*\]\([^\)]*\))/g, (match) => {
+        return `<span class="text-amber-600 dark:text-amber-400 font-medium">${match}</span>`;
+    });
+
+    // 6. Links ([text](url))
+    html = html.replace(/(\[[^\]]+\]\([^\)]+\))/g, (match) => {
+        return `<span class="text-sky-600 dark:text-sky-400 font-medium">${match}</span>`;
+    });
+
+    // 7. Bold (**text**)
+    html = html.replace(/(\*\*[^*]+\*\*)/g, (match) => {
+        return `<span class="font-bold text-zinc-950 dark:text-zinc-50">${match}</span>`;
+    });
+
+    // 8. Italic (*text* or _text_)
+    html = html.replace(/(\*[^*]+\*)/g, (match) => {
+        return `<span class="italic text-zinc-800 dark:text-zinc-200">${match}</span>`;
+    });
+    html = html.replace(/(_[^_]+_)/g, (match) => {
+        return `<span class="italic text-zinc-800 dark:text-zinc-200">${match}</span>`;
+    });
+
+    // 9. Strikethrough (~~text~~)
+    html = html.replace(/(~~[^~]+~~)/g, (match) => {
+        return `<span class="line-through text-zinc-400 dark:text-zinc-500">${match}</span>`;
+    });
+
+    return html;
+}
+
+// Scoped Markdown rendering CSS style template
+const PREVIEW_CSS_VARIABLES = `
+.markdown-preview {
+    --border-color: #e4e4e7;
+    --code-bg: #f4f4f5;
+    --code-border: #e4e4e7;
+    --inline-code-bg: #f4f4f5;
+    --inline-code-border: #e4e4e7;
+    --inline-code-color: #dc2626;
+    --quote-border: #d4d4d8;
+    --quote-color: #71717a;
+    --table-border: #e4e4e7;
+    --table-header-bg: #f4f4f5;
+    --table-row-even-bg: #fafafa;
+    --link-color: #2563eb;
+    --link-hover-color: #1d4ed8;
+}
+.dark .markdown-preview {
+    --border-color: #27272a;
+    --code-bg: #18181b;
+    --code-border: #27272a;
+    --inline-code-bg: #18181b;
+    --inline-code-border: #27272a;
+    --inline-code-color: #f43f5e;
+    --quote-border: #3f3f46;
+    --quote-color: #a1a1aa;
+    --table-border: #27272a;
+    --table-header-bg: #18181b;
+    --table-row-even-bg: #09090b;
+    --link-color: #3b82f6;
+    --link-hover-color: #60a5fa;
+}
+`;
+
+const PREVIEW_STYLES = `
+${PREVIEW_CSS_VARIABLES}
+.markdown-preview {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.6;
+    color: inherit;
+}
+.markdown-preview p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+.markdown-preview h1 {
+    font-size: 1.875rem;
+    font-weight: 700;
+    margin-top: 1.75rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.375rem;
+}
+.markdown-preview h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.25rem;
+}
+.markdown-preview h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+.markdown-preview h4 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+}
+.markdown-preview ul {
+    list-style-type: disc;
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+}
+.markdown-preview ol {
+    list-style-type: decimal;
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+}
+.markdown-preview li {
+    margin-bottom: 0.25rem;
+}
+.markdown-preview li > ul,
+.markdown-preview li > ol {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+}
+.markdown-preview pre {
+    background-color: var(--code-bg);
+    border: 1px solid var(--code-border);
+    border-radius: 0.375rem;
+    padding: 1rem;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+}
+.markdown-preview pre code {
+    background-color: transparent;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    font-size: 0.875rem;
+    color: inherit;
+}
+.markdown-preview code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875rem;
+    background-color: var(--inline-code-bg);
+    color: var(--inline-code-color);
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--inline-code-border);
+}
+.markdown-preview blockquote {
+    border-left: 4px solid var(--quote-border);
+    padding-left: 1rem;
+    color: var(--quote-color);
+    font-style: italic;
+    margin-bottom: 1rem;
+    margin-left: 0;
+    margin-right: 0;
+}
+.markdown-preview table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+.markdown-preview th,
+.markdown-preview td {
+    border: 1px solid var(--table-border);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+}
+.markdown-preview th {
+    background-color: var(--table-header-bg);
+    font-weight: 600;
+}
+.markdown-preview tr:nth-child(even) {
+    background-color: var(--table-row-even-bg);
+}
+.markdown-preview a {
+    color: var(--link-color);
+    text-decoration: underline;
+}
+.markdown-preview a:hover {
+    color: var(--link-hover-color);
+}
+.markdown-preview input[type="checkbox"] {
+    margin-right: 0.5rem;
+    vertical-align: middle;
+    cursor: pointer;
+}
+.markdown-preview hr {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: 1.5rem 0;
+}
+`;
+
+export default function MarkdownEditor() {
+    const [content, setContent] = useState(DEFAULT_MARKDOWN);
+    const [viewMode, setViewMode] = useState<"split" | "editor" | "preview">("split");
+    const [syncScroll, setSyncScroll] = useState(true);
+    const [copiedRaw, setCopiedRaw] = useState(false);
+    const [copiedHtml, setCopiedHtml] = useState(false);
+    const [mermaidInstance, setMermaidInstance] = useState<any>(null);
+    const [themeTick, setThemeTick] = useState(0); // Forces mermaid redraw on theme toggle
+
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const highlightRef = useRef<HTMLPreElement>(null);
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const previewContainerRef = useRef<HTMLDivElement>(null);
+
+    const isScrollingRef = useRef<"editor" | "preview" | null>(null);
+    const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+        };
+    }, []);
+
+    // Initialise Mermaid library on client side only
+    useEffect(() => {
+        import("mermaid").then((m) => {
+            const isDark = document.documentElement.classList.contains("dark");
+            m.default.initialize({
+                startOnLoad: false,
+                theme: isDark ? "dark" : "default",
+                securityLevel: "loose",
+                suppressErrorAlerts: true,
+            } as any);
+            setMermaidInstance(m.default);
+        });
+    }, []);
+
+    // Listen to dark mode switch triggers to change Mermaid themes dynamically
+    useEffect(() => {
+        if (!mermaidInstance) return;
+        
+        const observer = new MutationObserver(() => {
+            const isDark = document.documentElement.classList.contains("dark");
+            mermaidInstance.initialize({
+                startOnLoad: false,
+                theme: isDark ? "dark" : "default",
+                suppressErrorAlerts: true,
+            } as any);
+            
+            // Mark all mermaid blocks as unprocessed to trigger re-renders
+            const blocks = document.querySelectorAll(".mermaid-block");
+            blocks.forEach((block) => block.removeAttribute("data-processed"));
+            setThemeTick((t) => t + 1);
+        });
+
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["class"],
+        });
+
+        return () => observer.disconnect();
+    }, [mermaidInstance]);
+
+    // Setup custom Marked parser renderer for code blocks
+    const customRenderer = useMemo(() => {
+        return {
+            code(this: any, ...args: any[]) {
+                let text = "";
+                let lang = "";
+                if (typeof args[0] === "object" && args[0] !== null) {
+                    text = args[0].text || "";
+                    lang = args[0].lang || "";
+                } else {
+                    text = args[0] || "";
+                    lang = args[1] || "";
+                }
+
+                if (lang === "mermaid") {
+                    const encoded = encodeURIComponent(text);
+                    return `<div class="mermaid-block my-4 overflow-x-auto flex justify-center py-4 bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-lg" data-mermaid="${encoded}"></div>`;
+                }
+
+                const escapedText = text
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;");
+                return `<pre class="bg-zinc-50 dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 my-4 overflow-x-auto"><code class="language-${lang}">${escapedText}</code></pre>`;
+            }
+        };
+    }, []);
+
+    // Apply custom renderer configuration to marked
+    useEffect(() => {
+        marked.use({ renderer: customRenderer });
+    }, [customRenderer]);
+
+    // Pre-process markdown to auto-split unclosed code blocks if user omitted the newline before closing fence
+    const processedContent = useMemo(() => {
+        const lines = content.split("\n");
+        let inMermaid = false;
+        const processedLines = lines.map((line) => {
+            if (line.trim().startsWith("```mermaid")) {
+                inMermaid = true;
+                return line;
+            }
+            if (inMermaid) {
+                if (line.includes("```") && !line.trim().startsWith("```")) {
+                    inMermaid = false;
+                    return line.replace("```", "\n```");
+                }
+                if (line.trim() === "```") {
+                    inMermaid = false;
+                }
+            }
+            return line;
+        });
+        return processedLines.join("\n");
+    }, [content]);
+
+    // Compile Markdown to HTML
+    const previewHtml = useMemo(() => {
+        try {
+            const parsed = marked.parse(processedContent);
+            return typeof parsed === "string" ? parsed : "";
+        } catch (err) {
+            console.error("Marked parse error", err);
+            return `<div class="text-red-500 font-semibold p-4">Error parsing markdown content.</div>`;
+        }
+    }, [processedContent]);
+
+    // Render Mermaid diagrams in HTML preview
+    useEffect(() => {
+        if (!mermaidInstance) return;
+
+        const renderMermaid = async () => {
+            const blocks = document.querySelectorAll(".mermaid-block");
+            for (let i = 0; i < blocks.length; i++) {
+                const block = blocks[i] as HTMLElement;
+                if (block.getAttribute("data-processed") === "true") continue;
+
+                const encoded = block.getAttribute("data-mermaid");
+                if (!encoded) continue;
+
+                const code = decodeURIComponent(encoded);
+                const id = `mermaid-svg-${Math.random().toString(36).substring(2, 9)}`;
+
+                try {
+                    const cleanCode = code.trim();
+
+                    // Pre-validate graph syntax to avoid the browser-default red bomb SVG rendering
+                    let syntaxError: any = null;
+                    try {
+                        await mermaidInstance.parse(cleanCode);
+                    } catch (pe: any) {
+                        syntaxError = pe;
+                    }
+
+                    if (syntaxError) {
+                        // Display clean inline warning & fallback plain text editor content
+                        block.innerHTML = `
+                            <div class="my-2 border border-red-200 dark:border-red-950/40 rounded-lg overflow-hidden w-full text-left">
+                                <div class="bg-red-50 dark:bg-red-950/30 px-3 py-1.5 border-b border-red-200 dark:border-red-950/40 text-xs font-semibold text-red-600 dark:text-red-400 flex items-center gap-1.5">
+                                    <span>⚠ Mermaid Graph Syntax Error</span>
+                                </div>
+                                <pre class="bg-zinc-50/50 dark:bg-zinc-950/30 p-3 font-mono text-[11px] text-zinc-500 overflow-x-auto whitespace-pre border-b border-zinc-100 dark:border-zinc-850/50"><code>${cleanCode}</code></pre>
+                                <div class="p-3 bg-white dark:bg-zinc-900 text-red-500 dark:text-red-400 text-[11px] font-mono whitespace-pre-wrap">${syntaxError.message || String(syntaxError)}</div>
+                            </div>
+                        `;
+                        block.setAttribute("data-processed", "true");
+                        continue;
+                    }
+
+                    const { svg } = await mermaidInstance.render(id, cleanCode);
+                    block.innerHTML = svg;
+                    block.setAttribute("data-processed", "true");
+                } catch (err: any) {
+                    console.error("Mermaid error:", err);
+                    block.innerHTML = `
+                        <div class="p-4 bg-red-50 dark:bg-red-950/20 text-red-600 dark:text-red-400 text-xs rounded-lg border border-red-200 dark:border-red-900 w-full text-left font-mono">
+                            <div class="font-bold mb-1">⚠ Mermaid Rendering Error</div>
+                            <div class="whitespace-pre-wrap">${err.message || String(err)}</div>
+                        </div>
+                    `;
+                    block.setAttribute("data-processed", "true");
+                }
+            }
+        };
+
+        const timer = setTimeout(renderMermaid, 50);
+        return () => clearTimeout(timer);
+    }, [previewHtml, mermaidInstance, themeTick]);
+
+    const clearScrollLock = useCallback(() => {
+        if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+        scrollTimeoutRef.current = setTimeout(() => {
+            isScrollingRef.current = null;
+        }, 150);
+    }, []);
+
+    // Synchronize transparent textarea scroll with syntax highlight pre block, and optionally sync right pane scroll
+    const handleEditorScroll = useCallback(() => {
+        if (textareaRef.current && highlightRef.current) {
+            highlightRef.current.scrollTop = textareaRef.current.scrollTop;
+            highlightRef.current.scrollLeft = textareaRef.current.scrollLeft;
+        }
+
+        if (!syncScroll || viewMode !== "split") return;
+        if (isScrollingRef.current === "preview") return;
+
+        isScrollingRef.current = "editor";
+        if (scrollContainerRef.current && previewContainerRef.current) {
+            const editorEl = scrollContainerRef.current;
+            const previewEl = previewContainerRef.current;
+            
+            const editorScrollableHeight = editorEl.scrollHeight - editorEl.clientHeight;
+            if (editorScrollableHeight > 0) {
+                const percentage = editorEl.scrollTop / editorScrollableHeight;
+                const previewScrollableHeight = previewEl.scrollHeight - previewEl.clientHeight;
+                previewEl.scrollTop = percentage * previewScrollableHeight;
+            }
+        }
+        clearScrollLock();
+    }, [syncScroll, viewMode, clearScrollLock]);
+
+    const handlePreviewScroll = useCallback(() => {
+        if (!syncScroll || viewMode !== "split") return;
+        if (isScrollingRef.current === "editor") return;
+
+        isScrollingRef.current = "preview";
+        if (scrollContainerRef.current && previewContainerRef.current) {
+            const editorEl = scrollContainerRef.current;
+            const previewEl = previewContainerRef.current;
+
+            const previewScrollableHeight = previewEl.scrollHeight - previewEl.clientHeight;
+            if (previewScrollableHeight > 0) {
+                const percentage = previewEl.scrollTop / previewScrollableHeight;
+                const editorScrollableHeight = editorEl.scrollHeight - editorEl.clientHeight;
+                editorEl.scrollTop = percentage * editorScrollableHeight;
+            }
+        }
+        clearScrollLock();
+    }, [syncScroll, viewMode, clearScrollLock]);
+
+    // Sync line count inside editor gutter
+    const lineCount = useMemo(() => {
+        return content.split("\n").length || 1;
+    }, [content]);
+
+    // Toolbar insert logic
+    const insertMarkdown = useCallback((before: string, after: string, defaultText: string) => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        const text = ta.value;
+
+        const selection = text.slice(start, end) || defaultText;
+        const inserted = before + selection + after;
+        const newValue = text.slice(0, start) + inserted + text.slice(end);
+
+        setContent(newValue);
+
+        // Retain cursor and focus
+        requestAnimationFrame(() => {
+            ta.focus();
+            const newCursorStart = start + before.length;
+            const newCursorEnd = newCursorStart + selection.length;
+            ta.setSelectionRange(newCursorStart, newCursorEnd);
+        });
+    }, []);
+
+    // Clipboard Copy Raw Markdown
+    const handleCopyRaw = useCallback(() => {
+        navigator.clipboard.writeText(content)
+            .then(() => {
+                setCopiedRaw(true);
+                setTimeout(() => setCopiedRaw(false), 2000);
+            })
+            .catch((err) => {
+                console.error("Failed to copy raw markdown:", err);
+            });
+    }, [content]);
+
+    // Copy formatted HTML
+    const handleCopyHtml = useCallback(() => {
+        // Retrieve processed preview wrapper content
+        const previewEl = document.getElementById("markdown-preview-root");
+        const renderedHtml = previewEl ? previewEl.innerHTML : previewHtml;
+        
+        navigator.clipboard.writeText(renderedHtml)
+            .then(() => {
+                setCopiedHtml(true);
+                setTimeout(() => setCopiedHtml(false), 2000);
+            })
+            .catch((err) => {
+                console.error("Failed to copy formatted HTML:", err);
+            });
+    }, [previewHtml]);
+
+    // Export HTML download
+    const handleExportHtml = useCallback(() => {
+        const previewEl = document.getElementById("markdown-preview-root");
+        const renderedHtml = previewEl ? previewEl.innerHTML : previewHtml;
+
+        const template = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exported Document</title>
+    <style>
+        body {
+            max-width: 850px;
+            margin: 3rem auto;
+            padding: 0 1.5rem;
+            background-color: #ffffff;
+            color: #18181b;
+        }
+        @media (prefers-color-scheme: dark) {
+            body {
+                background-color: #09090b;
+                color: #fafafa;
+            }
+        }
+        ${PREVIEW_STYLES}
+    </style>
+</head>
+<body>
+    <div class="markdown-preview">
+        ${renderedHtml}
+    </div>
+</body>
+</html>`;
+
+        const blob = new Blob([template], { type: "text/html" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "document.html";
+        a.click();
+        URL.revokeObjectURL(url);
+    }, [previewHtml]);
+
+    // Export PDF via high-fidelity print popup window
+    const handleExportPdf = useCallback(() => {
+        const previewEl = document.getElementById("markdown-preview-root");
+        const renderedHtml = previewEl ? previewEl.innerHTML : previewHtml;
+
+        const printWindow = window.open("", "_blank", "width=850,height=600");
+        if (!printWindow) {
+            alert("Please allow pop-ups to export as PDF");
+            return;
+        }
+
+        printWindow.document.write(`<!DOCTYPE html>
+<html>
+<head>
+    <title>Print Document</title>
+    <style>
+        body {
+            max-width: 850px;
+            margin: 2rem auto;
+            padding: 0 1.5rem;
+            background-color: white;
+            color: #18181b;
+        }
+        ${PREVIEW_STYLES}
+        @media print {
+            body {
+                margin: 0;
+                padding: 0;
+                max-width: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="markdown-preview">
+        ${renderedHtml}
+    </div>
+    <script>
+        // Trigger print and close the window
+        window.onload = function() {
+            setTimeout(function() {
+                window.print();
+                window.close();
+            }, 300);
+        };
+    </script>
+</body>
+</html>`);
+        printWindow.document.close();
+    }, [previewHtml]);
+
+    // Interactive Checklist: Toggle checked/unchecked directly on preview panel clicks
+    const handlePreviewClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === "INPUT" && (target as HTMLInputElement).type === "checkbox") {
+            const previewEl = e.currentTarget;
+            const checkboxes = Array.from(previewEl.querySelectorAll('input[type="checkbox"]'));
+            const index = checkboxes.indexOf(target as HTMLInputElement);
+
+            if (index !== -1) {
+                let count = 0;
+                // Regular expression matches both checkboxes '[ ]' and '[x]/[X]'
+                const newContent = content.replace(/\[([ xX])\]/g, (match, state) => {
+                    if (count === index) {
+                        count++;
+                        return state === " " ? "[x]" : "[ ]";
+                    }
+                    count++;
+                    return match;
+                });
+                setContent(newContent);
+            }
+        }
+    }, [content]);
+
+    // Code Editor highlighted overlay HTML
+    const highlightedHtml = useMemo(() => {
+        const highlighted = highlightMarkdown(content);
+        // If content ends with a newline, append a space so the browser doesn't collapse the trailing blank line in <pre>
+        return content.endsWith("\n") ? highlighted + " " : highlighted;
+    }, [content]);
+
+    return (
+        <div className="flex flex-col gap-4">
+            {/* Scoped CSS styling for preview element */}
+            <style dangerouslySetInnerHTML={{ __html: PREVIEW_STYLES }} />
+
+            {/* Editor Workspace Action bar */}
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                {/* Left side: View Mode Switches & Sync Scroll toggle */}
+                <div className="flex flex-wrap items-center gap-3">
+                    <div className="flex items-center gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
+                        <button
+                            type="button"
+                            onClick={() => setViewMode("split")}
+                            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                                viewMode === "split"
+                                    ? "bg-white text-zinc-950 shadow-sm dark:bg-zinc-700 dark:text-white"
+                                    : "text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white"
+                            }`}
+                        >
+                            <Columns className="h-3.5 w-3.5" />
+                            <span className="hidden sm:inline">Split View</span>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setViewMode("editor")}
+                            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                                viewMode === "editor"
+                                    ? "bg-white text-zinc-950 shadow-sm dark:bg-zinc-700 dark:text-white"
+                                    : "text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white"
+                            }`}
+                        >
+                            <Edit3 className="h-3.5 w-3.5" />
+                            <span>Editor Only</span>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setViewMode("preview")}
+                            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                                viewMode === "preview"
+                                    ? "bg-white text-zinc-950 shadow-sm dark:bg-zinc-700 dark:text-white"
+                                    : "text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white"
+                            }`}
+                        >
+                            <Eye className="h-3.5 w-3.5" />
+                            <span>Preview Only</span>
+                        </button>
+                    </div>
+
+                    {viewMode === "split" && (
+                        <button
+                            type="button"
+                            onClick={() => setSyncScroll(!syncScroll)}
+                            className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition-all shadow-sm ${
+                                syncScroll
+                                    ? "bg-indigo-50 border-indigo-200 text-indigo-700 dark:bg-indigo-950/40 dark:border-indigo-900 dark:text-indigo-400"
+                                    : "bg-white border-zinc-200 text-zinc-700 hover:bg-zinc-50 dark:bg-zinc-900 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                            }`}
+                            title="Toggle synchronized scrolling"
+                        >
+                            <span>Sync Scroll: {syncScroll ? "ON" : "OFF"}</span>
+                        </button>
+                    )}
+                </div>
+
+                {/* Right side: Global Actions (Copy, Export, Clear) */}
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={handleCopyRaw}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        title="Copy raw Markdown"
+                    >
+                        {copiedRaw ? (
+                            <>
+                                <Check className="h-3.5 w-3.5 text-green-500" />
+                                <span>Copied!</span>
+                            </>
+                        ) : (
+                            <>
+                                <Copy className="h-3.5 w-3.5" />
+                                <span>Copy MD</span>
+                            </>
+                        )}
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={handleCopyHtml}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        title="Copy generated HTML body"
+                    >
+                        {copiedHtml ? (
+                            <>
+                                <Check className="h-3.5 w-3.5 text-green-500" />
+                                <span>Copied!</span>
+                            </>
+                        ) : (
+                            <>
+                                <FileText className="h-3.5 w-3.5" />
+                                <span>Copy HTML</span>
+                            </>
+                        )}
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={handleExportHtml}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        title="Export document as complete styled HTML file"
+                    >
+                        <ArrowDownToLine className="h-3.5 w-3.5" />
+                        <span>Export HTML</span>
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={handleExportPdf}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        title="Export document as PDF"
+                    >
+                        <Printer className="h-3.5 w-3.5" />
+                        <span>Export PDF</span>
+                    </button>
+
+                    <div className="h-6 w-px bg-zinc-200 dark:bg-zinc-800" />
+
+                    <button
+                        type="button"
+                        onClick={() => {
+                            if (window.confirm("Are you sure you want to clear editor content?")) {
+                                setContent("");
+                            }
+                        }}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50/50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-red-400 dark:hover:bg-red-950/20"
+                        title="Clear editor"
+                    >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        <span>Clear</span>
+                    </button>
+                </div>
+            </div>
+
+            {/* Layout Wrapper */}
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {/* Editor Container */}
+                <div
+                    className={`flex flex-col rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 overflow-hidden ${
+                        viewMode === "preview" ? "hidden" : ""
+                    } ${viewMode === "editor" ? "lg:col-span-2" : ""}`}
+                >
+                    {/* Formatting Toolbar */}
+                    <div className="flex flex-wrap items-center gap-1 border-b border-zinc-200 bg-zinc-50/50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900/50">
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("**", "**", "Bold Text")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Bold (**text**)"
+                        >
+                            <Bold className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("*", "*", "Italic Text")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Italic (*text*)"
+                        >
+                            <Italic className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("## ", "", "Heading")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Heading 2 (## Heading)"
+                        >
+                            <Heading className="h-4 w-4" />
+                        </button>
+
+                        <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-800" />
+
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("[", "](url)", "link text")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Link ([text](url))"
+                        >
+                            <Link className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("![", "](url)", "image description")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Image (![alt](url))"
+                        >
+                            <Image className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("`", "`", "code")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Inline Code (`code`)"
+                        >
+                            <Code className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("```javascript\n", "\n```", "console.log('hello');")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Code Block"
+                        >
+                            <FileText className="h-4 w-4" />
+                        </button>
+
+                        <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-800" />
+
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("- ", "", "Item")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Unordered List (- item)"
+                        >
+                            <List className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("1. ", "", "Item")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Ordered List (1. item)"
+                        >
+                            <ListOrdered className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("- [ ] ", "", "Task")}
+                            className="rounded p-1.5 text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Task List (- [ ] item)"
+                        >
+                            <CheckSquare className="h-4 w-4" />
+                        </button>
+
+                        <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-800" />
+
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |\n", "", "")}
+                            className="rounded p-1.5 text-xs font-semibold text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Table"
+                        >
+                            Table
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("~~", "~~", "Strikethrough")}
+                            className="rounded p-1.5 text-xs font-semibold text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Strikethrough (~~text~~)"
+                        >
+                            Del
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("> ", "", "Quote")}
+                            className="rounded p-1.5 text-xs font-semibold text-zinc-600 hover:bg-zinc-200 hover:text-zinc-950 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            title="Blockquote (> quote)"
+                        >
+                            Quote
+                        </button>
+
+                        <div className="mx-1 h-5 w-px bg-zinc-200 dark:bg-zinc-800" />
+
+                        <button
+                            type="button"
+                            onClick={() => insertMarkdown("\n```mermaid\ngraph TD\n    A[Start] --> B(Process)\n    B --> C{Choice}\n    C -->|Yes| D[Result 1]\n    C -->|No| E[Result 2]\n```\n", "", "")}
+                            className="inline-flex items-center gap-1 rounded bg-indigo-50 dark:bg-indigo-950/40 px-2 py-1 text-[11px] font-bold text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 hover:text-indigo-700 dark:hover:bg-indigo-950/70"
+                            title="Insert Mermaid Graph Template"
+                        >
+                            + Graph
+                        </button>
+                    </div>
+
+                    {/* Integrated Scroll synced editor viewport (gutter + textarea + highlighter grid) */}
+                    <div
+                        ref={scrollContainerRef}
+                        onScroll={handleEditorScroll}
+                        className="flex flex-1 min-h-[450px] max-h-[70vh] overflow-auto bg-white dark:bg-zinc-900"
+                    >
+                        {/* Line number gutter */}
+                        <div
+                            className="shrink-0 self-start select-none border-r border-zinc-200 bg-zinc-50 py-4 pr-3 pl-3 text-right font-mono text-[13px] leading-relaxed text-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-600"
+                            aria-hidden="true"
+                        >
+                            {Array.from({ length: lineCount }, (_, i) => (
+                                <div key={i}>{i + 1}</div>
+                            ))}
+                        </div>
+
+                        {/* Editor overlay container */}
+                        <div className="flex-1 self-start relative">
+                            <div className="grid [&>*]:col-start-1 [&>*]:row-start-1 h-full w-full">
+                                {/* Highlight Layer (rendered behind transparent textarea) */}
+                                <pre
+                                    ref={highlightRef}
+                                    className="pointer-events-none whitespace-pre p-4 font-mono text-[13px] leading-relaxed overflow-hidden h-full w-full"
+                                    aria-hidden="true"
+                                    dangerouslySetInnerHTML={{
+                                        __html: highlightedHtml || "&nbsp;",
+                                    }}
+                                />
+
+                                {/* Interactive Textarea Layer */}
+                                <textarea
+                                    ref={textareaRef}
+                                    value={content}
+                                    onChange={(e) => setContent(e.target.value)}
+                                    placeholder="Start writing markdown, or click a toolbar button to insert templates..."
+                                    spellCheck={false}
+                                    wrap="off"
+                                    className={`relative z-10 block w-full h-full min-h-[450px] resize-none whitespace-pre bg-transparent p-4 font-mono text-[13px] leading-relaxed outline-none border-0 focus:ring-0 ${
+                                        content
+                                            ? "text-transparent caret-zinc-800 dark:caret-zinc-200"
+                                            : "text-zinc-900 dark:text-zinc-100"
+                                    }`}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Preview Container */}
+                <div
+                    className={`flex flex-col rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 overflow-hidden ${
+                        viewMode === "editor" ? "hidden" : ""
+                    } ${viewMode === "preview" ? "lg:col-span-2" : ""}`}
+                >
+                    {/* Preview Header */}
+                    <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-50/50 px-4 py-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+                        <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider">Live Preview</span>
+                        <span className="text-[10px] text-zinc-400 dark:text-zinc-500 flex items-center gap-1">
+                            <HelpCircle className="h-3 w-3" />
+                            GFM + Diagrams active
+                        </span>
+                    </div>
+
+                    {/* Styled rendered content container */}
+                    <div
+                        ref={previewContainerRef}
+                        onScroll={handlePreviewScroll}
+                        className="flex-1 min-h-[450px] max-h-[70vh] overflow-y-auto p-6 bg-white dark:bg-zinc-900"
+                    >
+                        <div
+                            id="markdown-preview-root"
+                            className="markdown-preview min-h-full text-zinc-800 dark:text-zinc-100"
+                            dangerouslySetInnerHTML={{ __html: previewHtml }}
+                            onClick={handlePreviewClick}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/tools/managers/markdown-editor/index.ts
+++ b/src/tools/managers/markdown-editor/index.ts
@@ -1,0 +1,12 @@
+import type { ToolMeta } from "@/lib/tool-registry";
+
+export const toolMeta: ToolMeta = {
+    name: "Markdown Editor",
+    slug: "markdown-editor",
+    description: "Write and preview Markdown in a split-pane editor with live rendering.",
+    category: "managers",
+    keywords: [
+        "markdown", "editor", "preview", "gfm", "commonmark", "writer",
+        "wysiwyg", "mermaid", "diagram", "graph", "chart",
+    ],
+};


### PR DESCRIPTION
## Summary

Adds a new **Markdown Editor** tool under the Managers category — a split-pane editor with live GFM preview, syntax highlighting, Mermaid diagram support, and export options.

### Editor

- **Split / editor-only / preview-only** view modes with responsive layout (stacks on mobile, side-by-side on desktop)
- **Syntax-highlighted editor** — transparent textarea over a highlighted `<pre>` overlay for headings, lists, task items, code, links, bold/italic, strikethrough, and blockquotes
- **Line-number gutter** synced with editor scroll
- **Formatting toolbar** — quick-insert buttons for bold, italic, headings, links, images, code blocks, lists, task lists, tables, blockquotes, strikethrough, and Mermaid graph templates
- **Sync scroll toggle** — optional linked scrolling between editor and preview panes in split view

### Preview

- **Live GFM rendering** via `marked` with scoped preview CSS (headings, tables, blockquotes, code blocks, links) and light/dark theme support
- **Mermaid.js diagrams** — ` ```mermaid ` code blocks render as SVG flowcharts, sequence diagrams, etc.; theme follows app dark mode via `MutationObserver`
- **Graceful Mermaid error handling** — syntax errors show an inline warning with source and message instead of a broken SVG
- **Interactive task lists** — clicking checkboxes in the preview toggles `[ ]` / `[x]` in the source markdown

### Export & actions

- Copy raw Markdown
- Copy rendered HTML body
- Export as standalone styled `.html` file
- Export as PDF via browser print dialog
- Clear editor with confirmation

### Routing & registry

- Registered at `/tools/managers/markdown-editor`
- Alias route at `/tools/manager/markdown-editor` (singular) for category normalization
- `getToolBySlug` now normalizes `manager` → `managers` for lookup consistency

### Dependencies

- `marked` — Markdown parsing
- `mermaid` — diagram rendering (client-side dynamic import)

## Files changed

| File | Change |
|------|--------|
| `src/tools/managers/markdown-editor/MarkdownEditor.tsx` | Main editor component |
| `src/tools/managers/markdown-editor/index.ts` | Tool metadata export |
| `src/app/tools/managers/markdown-editor/page.tsx` | App route page |
| `src/app/tools/manager/markdown-editor/page.tsx` | Singular alias route |
| `src/lib/tool-registry.ts` | Tool registration + category alias fix |
| `src/lib/tool-components.ts` | Component mapping |
| `src/lib/routes.ts` | Route constant |
| `package.json` / `package-lock.json` | New dependencies |

## Test plan

- [ ] Open `/tools/managers/markdown-editor` — default sample content loads with split view
- [ ] Switch between Split, Editor Only, and Preview Only modes
- [ ] Toggle Sync Scroll ON/OFF and verify editor/preview scroll together in split view
- [ ] Use toolbar buttons to insert formatting; confirm cursor/selection behavior
- [ ] Verify syntax highlighting in editor for headings, lists, code, links, bold/italic
- [ ] Confirm Mermaid diagrams render (flowchart and sequence diagram in sample)
- [ ] Introduce invalid Mermaid syntax — inline error panel should appear
- [ ] Click task list checkboxes in preview — source markdown should update
- [ ] Copy MD, Copy HTML, Export HTML, and Export PDF actions work
- [ ] Test `/tools/manager/markdown-editor` alias route resolves correctly
- [ ] Toggle dark mode — preview styles and Mermaid theme update
- [ ] Verify tool appears in search with keywords (markdown, mermaid, editor, etc.)


Closes #40 