### PR TITLE
fix(markdown-editor): restore horizontal scroll in syntax highlight layer

### DIFF
--- a/src/tools/managers/markdown-editor/MarkdownEditor.tsx
+++ b/src/tools/managers/markdown-editor/MarkdownEditor.tsx
@@ -1063,7 +1063,7 @@ export default function MarkdownEditor() {
                                 {/* Highlight Layer (rendered behind transparent textarea) */}
                                 <pre
                                     ref={highlightRef}
-                                    className="pointer-events-none whitespace-pre p-4 font-mono text-[13px] leading-relaxed overflow-hidden h-full w-full"
+                                    className="pointer-events-none whitespace-pre p-4 font-mono text-[13px] leading-relaxed"
                                     aria-hidden="true"
                                     dangerouslySetInnerHTML={{
                                         __html: highlightedHtml || "&nbsp;",


### PR DESCRIPTION
## Summary

Fixes horizontal scrolling in the Markdown Editor when editing long lines (e.g. URLs, code, or unwrapped text).

### Problem

The syntax highlight overlay `<pre>` behind the transparent textarea used `overflow-hidden` along with `h-full w-full`. This clipped content wider than the viewport and prevented the parent scroll container from scrolling horizontally — the textarea could scroll, but the highlight layer did not expand, causing misalignment and making horizontal scroll appear broken.

### Fix

Removed `overflow-hidden`, `h-full`, and `w-full` from the highlight `<pre>` element so it naturally expands to fit long lines. The parent scroll container (`scrollContainerRef`) already handles both vertical and horizontal overflow, and the existing `handleEditorScroll` sync keeps `scrollLeft` aligned between the textarea and highlight layer.

## Files changed

| File | Change |
|------|--------|
| `src/tools/managers/markdown-editor/MarkdownEditor.tsx` | Remove clipping/sizing constraints on highlight pre |

## Test plan

- [ ] Open `/tools/managers/markdown-editor`
- [ ] Paste or type a very long unbroken line (e.g. a long URL or code string)
- [ ] Confirm horizontal scrollbar appears on the editor pane
- [ ] Scroll horizontally — syntax highlighting stays aligned with the textarea text
- [ ] Verify vertical scroll and sync scroll with preview still work in split view
- [ ] Test in dark mode — no visual regressions in the highlight overlay

