### PR TITLE
Fix of Font Ligatures issue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,3 +91,12 @@ body {
 .animate-slide-in-right {
   animation: slide-in-right 0.25s ease-out;
 }
+
+/* Disable font ligatures in monospaced code elements to prevent layout shifting, character overlap, and cursor drift */
+.font-mono,
+pre,
+code,
+textarea {
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "calt" 0, "clig" 0, "dlig" 0;
+}


### PR DESCRIPTION
Root Cause Analysis
Modern monospaced coding fonts (like Geist Mono, Fira Code, or JetBrains Mono) have Font Ligatures enabled by default.

In custom web editors that align a transparent textarea on top of a syntax-highlighted pre container, font ligatures present two issues:

1. Ligature Splitting: If a syntax-highlighting function wraps part of the character sequence in a <span> tag, it breaks the ligature in the pre layer but not in the transparent <textarea> layer.
2. Width Discrepancy: A ligature merges multiple characters into a single glyph. The width of this unified glyph is often narrower than the sum of the individual characters. If the browser measures cursor positioning based on individual character widths, the caret drifts away from the text position.
This causes the two layers to render at different widths, leading to characters overlapping and cursor displacement.

Fix / Workaround
Disable font ligatures for monospaced input/output containers to force characters to render with strict monospace metrics. 

Closes #72 