### PR TITLE
fix: refactor Redis client initialization to resolve Netlify build failures

### DIFF
--- a/src/app/api/broadcast/route.ts
+++ b/src/app/api/broadcast/route.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import * as emoji from "node-emoji";
-import { createClient } from "redis";
+import { getRedis } from "@/lib/redis";
 
 export const dynamic = "force-dynamic";
-
-// Create client using the Vercel Redis URL
-const redis = await createClient({
-    url: process.env.TOOLICH_STORAGE_REDIS_URL,
-}).connect();
 
 interface BroadcastData {
     text?: string;
@@ -17,6 +12,7 @@ interface BroadcastData {
 // Helper to read broadcast from Redis
 async function readBroadcast(): Promise<BroadcastData> {
     try {
+        const redis = await getRedis();
         const dataStr = await redis.get("toolich:broadcast");
         if (dataStr) {
             return JSON.parse(dataStr);
@@ -30,6 +26,7 @@ async function readBroadcast(): Promise<BroadcastData> {
 // Helper to write broadcast to Redis
 async function writeBroadcast(data: BroadcastData) {
     try {
+        const redis = await getRedis();
         if (!data.text || !data.timestamp) {
             // Delete the key to free up Redis memory
             await redis.del("toolich:broadcast");

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,10 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "redis";
-
-// Create client using the Vercel Redis URL
-const redis = await createClient({
-    url: process.env.TOOLICH_STORAGE_REDIS_URL,
-}).connect();
+import { getRedis } from "@/lib/redis";
 
 export async function POST(request: Request) {
     try {
@@ -66,6 +61,7 @@ export async function POST(request: Request) {
 
         // 3. Persist feedback list in Redis
         try {
+            const redis = await getRedis();
             await redis.lPush(
                 "toolich:feedback_list",
                 JSON.stringify({

--- a/src/app/api/test-redis/route.ts
+++ b/src/app/api/test-redis/route.ts
@@ -1,13 +1,9 @@
-import { createClient } from "redis";
+import { getRedis } from "@/lib/redis";
 import { NextResponse } from "next/server";
-
-// Create client using the Vercel Redis URL
-const redis = await createClient({
-    url: process.env.TOOLICH_STORAGE_REDIS_URL,
-}).connect();
 
 export async function POST() {
     try {
+        const redis = await getRedis();
         // Fetch data from Redis
         const result = await redis.get("item");
 

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,14 @@
+import { createClient } from "redis";
+
+let redisClient: ReturnType<typeof createClient> | null = null;
+
+export async function getRedis() {
+    if (!redisClient) {
+        const client: ReturnType<typeof createClient> = createClient({
+            url: process.env.TOOLICH_STORAGE_REDIS_URL,
+        });
+        await client.connect();
+        redisClient = client;
+    }
+    return redisClient!;
+}


### PR DESCRIPTION
### Summary
This PR fixes the build-time connection failures on Netlify (Exit Code 2/1) by refactoring the Redis connection strategy. It introduces lazy loading for the database connection instead of initializing it at the module evaluation level.

### Changes
- **Lazy Redis client loading**:
  - Added [`src/lib/redis.ts`](file:///Users/cratonik/Work/toolich/src/lib/redis.ts) to manage the Redis client instance as a lazy singleton.
  - Replaced top-level `await createClient(...).connect()` in all API routes with runtime calls to the lazy `getRedis()` helper inside the endpoints.
  - This prevents Next.js from attempting to connect to Redis during the build/pre-rendering phase (when variables aren't exposed), resolving `ECONNREFUSED` failures on Netlify.
- **Strict Typing**:
  - Explicitly typed the internal Redis client with `ReturnType<typeof createClient>` to retain full, compiler-checked typesafety.

---

### Files Changed
- [NEW] [`src/lib/redis.ts`](file:///Users/cratonik/Work/toolich/src/lib/redis.ts)
- [MODIFY] [`src/app/api/broadcast/route.ts`](file:///Users/cratonik/Work/toolich/src/app/api/broadcast/route.ts)
- [MODIFY] [`src/app/api/feedback/route.ts`](file:///Users/cratonik/Work/toolich/src/app/api/feedback/route.ts)
- [MODIFY] [`src/app/api/test-redis/route.ts`](file:///Users/cratonik/Work/toolich/src/app/api/test-redis/route.ts)
