### PR TITLE
feat: implement comprehensive SEO configurations and JSON-LD structured schemas

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/lib/theme-context";
 import { ToastProvider } from "@/components/Toast";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Script from "next/script";
+import { HomeStructuredData } from "@/components/StructuredData";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -87,6 +88,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <HomeStructuredData />
         {/* Google Analytics & AdSense via next/script */}
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-Q4GXZK2JXF"

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,10 +1,11 @@
-import type { Metadata } from "next";
 import PrivacyPageClient from "./PrivacyPageClient";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-    title: "Privacy Policy | Toolich",
+export const metadata = constructMetadata({
+    title: "Privacy Policy",
     description: "Toolich privacy policy — how we handle your data.",
-};
+    path: "/privacy",
+});
 
 export default function PrivacyPage() {
     return <PrivacyPageClient />;

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,10 +1,11 @@
-import type { Metadata } from "next";
 import TermsPageClient from "./TermsPageClient";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-    title: "Terms of Service | Toolich",
-    description: "Toolich terms of service.",
-};
+export const metadata = constructMetadata({
+    title: "Terms of Service",
+    description: "Toolich terms of service and conditions of use.",
+    path: "/terms",
+});
 
 export default function TermsPage() {
     return <TermsPageClient />;

--- a/src/app/tools/developers/base64-decode/page.tsx
+++ b/src/app/tools/developers/base64-decode/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import Base64Decoder from "@/tools/developers/base64-decode/Base64Decoder";
 import { toolMeta } from "@/tools/developers/base64-decode";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function Base64DecodePage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <Base64Decoder />
         </>

--- a/src/app/tools/developers/base64-encode/page.tsx
+++ b/src/app/tools/developers/base64-encode/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import Base64Encoder from "@/tools/developers/base64-encode/Base64Encoder";
 import { toolMeta } from "@/tools/developers/base64-encode";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function Base64EncodePage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <Base64Encoder />
         </>

--- a/src/app/tools/developers/json-formatter/page.tsx
+++ b/src/app/tools/developers/json-formatter/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import JsonFormatter from "@/tools/developers/json-formatter/JsonFormatter";
 import { toolMeta } from "@/tools/developers/json-formatter";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function JsonFormatterPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <JsonFormatter />
         </>

--- a/src/app/tools/developers/json-to-schema/page.tsx
+++ b/src/app/tools/developers/json-to-schema/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import JsonToSchema from "@/tools/developers/json-to-schema/JsonToSchema";
 import { toolMeta } from "@/tools/developers/json-to-schema";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function JsonToSchemaPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <JsonToSchema />
         </>

--- a/src/app/tools/developers/page.tsx
+++ b/src/app/tools/developers/page.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Code, ArrowRight } from "lucide-react";
 import { getToolsByCategory } from "@/lib/tool-registry";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata = {
-    title: "Developer Tools | Toolich",
-    description: "Code formatters, converters, validators, and generators.",
-};
+export const metadata = constructMetadata({
+    title: "Developer Tools",
+    description: "Code formatters, base64 converters, schema validators, and UUID generators.",
+    path: "/tools/developers",
+    keywords: ["developer tools", "code formatters", "validators", "base64", "json schema"],
+});
 
 export default function DevelopersPage() {
     const tools = getToolsByCategory("developers");

--- a/src/app/tools/developers/uuid-generator/page.tsx
+++ b/src/app/tools/developers/uuid-generator/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import UuidGenerator from "@/tools/developers/uuid-generator/UuidGenerator";
 import { toolMeta } from "@/tools/developers/uuid-generator";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function UuidGeneratorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <UuidGenerator />
         </>

--- a/src/app/tools/devops/cron-parser/page.tsx
+++ b/src/app/tools/devops/cron-parser/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import CronParser from "@/tools/devops/cron-parser/CronParser";
 import { toolMeta } from "@/tools/devops/cron-parser";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function CronParserPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <CronParser />
         </>

--- a/src/app/tools/devops/env-editor/page.tsx
+++ b/src/app/tools/devops/env-editor/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import EnvEditor from "@/tools/devops/env-editor/EnvEditor";
 import { toolMeta } from "@/tools/devops/env-editor";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function EnvEditorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <EnvEditor />
         </>

--- a/src/app/tools/devops/page.tsx
+++ b/src/app/tools/devops/page.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Server, ArrowRight } from "lucide-react";
 import { getToolsByCategory } from "@/lib/tool-registry";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata = {
-    title: "DevOps Tools | Toolich",
-    description: "Docker, Kubernetes, CI/CD, and infrastructure helpers.",
-};
+export const metadata = constructMetadata({
+    title: "DevOps Tools",
+    description: "Cron parser, environment variable editor, regex tester, and infrastructure configuration utilities.",
+    path: "/tools/devops",
+    keywords: ["devops tools", "cron parser", "dotenv editor", "regex tester", "infrastructure helper"],
+});
 
 export default function DevOpsPage() {
     const tools = getToolsByCategory("devops");

--- a/src/app/tools/devops/regex-tester/page.tsx
+++ b/src/app/tools/devops/regex-tester/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import RegexTester from "@/tools/devops/regex-tester/RegexTester";
 import { toolMeta } from "@/tools/devops/regex-tester";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function RegexTesterPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <RegexTester />
         </>

--- a/src/app/tools/manager/markdown-editor/page.tsx
+++ b/src/app/tools/manager/markdown-editor/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import MarkdownEditor from "@/tools/managers/markdown-editor/MarkdownEditor";
 import { toolMeta } from "@/tools/managers/markdown-editor";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function MarkdownEditorPageSingular() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category="manager"
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <MarkdownEditor />
         </>

--- a/src/app/tools/managers/diff-checker/page.tsx
+++ b/src/app/tools/managers/diff-checker/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import DiffChecker from "@/tools/managers/diff-checker/DiffChecker";
 import { toolMeta } from "@/tools/managers/diff-checker";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function DiffCheckerPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <DiffChecker />
         </>

--- a/src/app/tools/managers/markdown-editor/page.tsx
+++ b/src/app/tools/managers/markdown-editor/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import MarkdownEditor from "@/tools/managers/markdown-editor/MarkdownEditor";
 import { toolMeta } from "@/tools/managers/markdown-editor";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function MarkdownEditorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <MarkdownEditor />
         </>

--- a/src/app/tools/managers/page.tsx
+++ b/src/app/tools/managers/page.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { BarChart3, ArrowRight } from "lucide-react";
 import { getToolsByCategory } from "@/lib/tool-registry";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata = {
-    title: "Manager Tools | Toolich",
-    description: "Sprint calculators, time zone helpers, and productivity tools.",
-};
+export const metadata = constructMetadata({
+    title: "Manager Tools",
+    description: "Markdown editor, side-by-side text diff checkers, and productivity tools for project managers and developers.",
+    path: "/tools/managers",
+    keywords: ["manager tools", "markdown editor", "diff checker", "productivity utilities"],
+});
 
 export default function ManagersPage() {
     const tools = getToolsByCategory("managers");

--- a/src/app/tools/networking/dns-lookup/page.tsx
+++ b/src/app/tools/networking/dns-lookup/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import DnsLookup from "@/tools/networking/dns-lookup/DnsLookup";
 import { toolMeta } from "@/tools/networking/dns-lookup";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function DnsLookupPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <DnsLookup />
         </>

--- a/src/app/tools/networking/page.tsx
+++ b/src/app/tools/networking/page.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Network, ArrowRight } from "lucide-react";
 import { getToolsByCategory } from "@/lib/tool-registry";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata = {
-    title: "Networking Tools | Toolich",
-    description: "IP tools, DNS lookup, URL utilities, and network testing.",
-};
+export const metadata = constructMetadata({
+    title: "Networking Tools",
+    description: "IP subnet calculators, DNS lookup utilities, network analysis, and network testing helper tools.",
+    path: "/tools/networking",
+    keywords: ["networking tools", "subnet calculator", "dns lookup", "ip tools", "network utility"],
+});
 
 export default function NetworkingPage() {
     const tools = getToolsByCategory("networking");

--- a/src/app/tools/networking/subnet-calculator/page.tsx
+++ b/src/app/tools/networking/subnet-calculator/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import SubnetCalculator from "@/tools/networking/subnet-calculator/SubnetCalculator";
 import { toolMeta } from "@/tools/networking/subnet-calculator";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function SubnetCalculatorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <SubnetCalculator />
         </>

--- a/src/app/tools/security/hash-generator/page.tsx
+++ b/src/app/tools/security/hash-generator/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import HashGenerator from "@/tools/security/hash-generator/HashGenerator";
 import { toolMeta } from "@/tools/security/hash-generator";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function HashGeneratorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <HashGenerator />
         </>

--- a/src/app/tools/security/page.tsx
+++ b/src/app/tools/security/page.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Shield, ArrowRight } from "lucide-react";
 import { getToolsByCategory } from "@/lib/tool-registry";
+import { constructMetadata } from "@/lib/seo";
 
-export const metadata = {
-    title: "Security Tools | Toolich",
-    description: "Encryption, password tools, JWT, and security checkers.",
-};
+export const metadata = constructMetadata({
+    title: "Security Tools",
+    description: "Cryptographic hash generators, secure password generators, and client-side encryption utility tools.",
+    path: "/tools/security",
+    keywords: ["security tools", "hash generator", "password generator", "encryption", "cryptography"],
+});
 
 export default function SecurityPage() {
     const tools = getToolsByCategory("security");

--- a/src/app/tools/security/password-generator/page.tsx
+++ b/src/app/tools/security/password-generator/page.tsx
@@ -1,19 +1,28 @@
 import { ToolPageHeader } from "@/components/ToolPageHeader";
 import PasswordGenerator from "@/tools/security/password-generator/PasswordGenerator";
 import { toolMeta } from "@/tools/security/password-generator";
+import { constructMetadata } from "@/lib/seo";
+import { ToolStructuredData } from "@/components/StructuredData";
+import { allTools } from "@/lib/tool-registry";
 
-export const metadata = {
-    title: `${toolMeta.name} | Toolich`,
-    description: toolMeta.description,
-};
+const meta = allTools.find((t) => t.slug === toolMeta.slug)!;
+
+export const metadata = constructMetadata({
+    title: meta.name,
+    description: meta.description,
+    path: meta.slug === "markdown-editor" && toolMeta.category === "manager" ? "/tools/managers/markdown-editor" : meta.path,
+    keywords: meta.keywords,
+});
 
 export default function PasswordGeneratorPage() {
     return (
         <>
+            <ToolStructuredData tool={meta} />
             <ToolPageHeader
-                toolName={toolMeta.name}
-                description={toolMeta.description}
-                category={toolMeta.category}
+                toolName={meta.name}
+                description={meta.description}
+                category={meta.category}
+                slug={meta.slug}
             />
             <PasswordGenerator />
         </>

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,0 +1,46 @@
+import type { ToolMetaWithPath } from "@/lib/tool-registry";
+
+export function ToolStructuredData({ tool }: { tool: ToolMetaWithPath }) {
+    const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": tool.name,
+        "description": tool.description,
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "All",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+        },
+        "url": `https://toolich.com${tool.path}`,
+    };
+
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+    );
+}
+
+export function HomeStructuredData() {
+    const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Toolich",
+        "url": "https://toolich.com",
+        "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://toolich.com/?q={search_term_string}",
+            "query-input": "required name=search_term_string",
+        },
+    };
+
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+    );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+
+interface MetadataInput {
+    title: string;
+    description: string;
+    path: string;
+    keywords?: string[];
+}
+
+export function constructMetadata({
+    title,
+    description,
+    path,
+    keywords = [],
+}: MetadataInput): Metadata {
+    const siteUrl = "https://toolich.com";
+    const fullUrl = `${siteUrl}${path}`;
+
+    return {
+        title: `${title} | Toolich`,
+        description,
+        keywords: [
+            ...keywords,
+            "developer tools",
+            "online utilities",
+            "free web tools",
+            "DevOps helpers",
+            "programming tools",
+            "code formatters",
+        ],
+        alternates: {
+            canonical: fullUrl,
+        },
+        openGraph: {
+            type: "website",
+            title: `${title} | Toolich`,
+            description,
+            url: fullUrl,
+            siteName: "Toolich",
+            locale: "en_US",
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: `${title} | Toolich`,
+            description,
+        },
+    };
+}


### PR DESCRIPTION
### Summary
This PR implements full search engine optimization (SEO) best practices across the platform to maximize organic discoverability, activate search rich snippets (Sitelinks Searchbox and SoftwareApplication specs), and establish correct canonical URLs.

### Changes
- **SEO & Metadata Builders**:
  - Added [`src/lib/seo.ts`](file:///Users/cratonik/Work/toolich/src/lib/seo.ts) exposing a unified `constructMetadata()` helper to generate titles, descriptions, canonical URLs, keywords, OpenGraph, and Twitter tags consistently.
  - Added [`src/components/StructuredData.tsx`](file:///Users/cratonik/Work/toolich/src/components/StructuredData.tsx) to manage dynamic JSON-LD injection.
- **Rich Snippets & JSON-LD**:
  - Embedded Website schema (`HomeStructuredData`) inside the root layout `<head>` to support Google Sitelinks Searchbox integration.
  - Integrated `SoftwareApplication` dynamic schemas (`ToolStructuredData`) on all 15 tool routes, detailing free pricing tiers and developer application categorization directly to search engines.
- **Route Canonicals & Keywords**:
  - Configured custom metadata overrides on static routes (`/privacy`, `/terms`) and the 5 main category indexes (Developers, DevOps, Managers, Networking, Security).
  - Explicitly mapped duplicate routes (e.g. `/tools/manager/markdown-editor` and `/tools/managers/markdown-editor`) to a single canonical path to prevent duplicate content index penalties.

---

### Files Changed
- [NEW] [`src/lib/seo.ts`](file:///Users/cratonik/Work/toolich/src/lib/seo.ts)
- [NEW] [`src/components/StructuredData.tsx`](file:///Users/cratonik/Work/toolich/src/components/StructuredData.tsx)
- [MODIFY] [`src/app/layout.tsx`](file:///Users/cratonik/Work/toolich/src/app/layout.tsx)
- [MODIFY] [`src/app/privacy/page.tsx`](file:///Users/cratonik/Work/toolich/src/app/privacy/page.tsx)
- [MODIFY] [`src/app/terms/page.tsx`](file:///Users/cratonik/Work/toolich/src/app/terms/page.tsx)
- [MODIFY] All tool route `page.tsx` files (15 files)
- [MODIFY] All category index `page.tsx` files (5 files)
