### PR TITLE
Deploy: Replace hardcoded Redis URL with environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - "4000:4000" # Exposes your app on port 4000 for your reverse proxy
     environment:
       - NODE_ENV=production
-      - TOOLICH_STORAGE_REDIS_URL=redis://default:esoaoGZZHp37sxuokTxPXJBgbehtanrp@round-proactive-veracious-95723.db.redis.io:12785
-      - REDIS_URL=redis://default:esoaoGZZHp37sxuokTxPXJBgbehtanrp@round-proactive-veracious-95723.db.redis.io:12785
+      - TOOLICH_STORAGE_REDIS_URL=${TOOLICH_STORAGE_REDIS_URL}
+      - REDIS_URL=${REDIS_URL}


### PR DESCRIPTION
This PR merges dev into prod to update the docker-compose.yml file to use environment variable placeholders instead of hardcoded Redis credentials.