### PR TITLE
Deploy: Declare external proxy-network in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   toolich-web:
     build:
@@ -7,9 +5,15 @@ services:
       dockerfile: Dockerfile
     container_name: toolich_app
     restart: unless-stopped
+    networks:
+      - proxy-network
     ports:
-      - "4000:4000" # Exposes your app on port 4000 for your reverse proxy
+      - "4000:4000"
     environment:
       - NODE_ENV=production
       - TOOLICH_STORAGE_REDIS_URL=${TOOLICH_STORAGE_REDIS_URL}
       - REDIS_URL=${REDIS_URL}
+
+networks:
+  proxy-network:
+    external: true


### PR DESCRIPTION
This PR updates docker-compose.yml to declare the external proxy-network at the root level, enabling secure container-to-container routing.