### PR TITLE
feat(blogs): add blogs section with SEO improvements

### DIFF
--- a/src/app/blogs/[title]/page.tsx
+++ b/src/app/blogs/[title]/page.tsx
@@ -1,0 +1,135 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import Footer from '@/components/Footer';
+import { StaticFloatingDock } from "@/components/StaticFloatingDock";
+
+type Props = {
+  params: Promise<{ title: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { title } = await params;
+  const titleSlug = title;
+  
+  const res = await fetch('https://www.cratonik.com/api/blog');
+  if (!res.ok) return { title: 'Not Found' };
+  
+  const blogs = await res.json();
+  const blog = blogs.find((b: any) => 
+    encodeURIComponent(b.title.replace(/\s+/g, '-').toLowerCase()) === titleSlug || 
+    b.title.replace(/\s+/g, '-').toLowerCase() === decodeURIComponent(titleSlug)
+  );
+  
+  if (!blog) return { title: 'Not Found' };
+  
+  const imageUrl = `https://www.cratonik.com${blog.image}`;
+  
+  return { 
+    title: blog.title, 
+    description: blog.para1,
+    openGraph: {
+      title: blog.title,
+      description: blog.para1,
+      type: "article",
+      publishedTime: blog.createdAt,
+      authors: [blog.author],
+      images: [{ url: imageUrl }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: blog.title,
+      description: blog.para1,
+      images: [imageUrl],
+    }
+  };
+}
+
+export default async function BlogDetail({ params }: Props) {
+  const { title } = await params;
+  const titleSlug = title;
+  
+  const res = await fetch('https://www.cratonik.com/api/blog', { next: { revalidate: 3600 } });
+  if (!res.ok) return notFound();
+  
+  const blogs = await res.json();
+  const blog = blogs.find((b: any) => 
+    encodeURIComponent(b.title.replace(/\s+/g, '-').toLowerCase()) === titleSlug || 
+    b.title.replace(/\s+/g, '-').toLowerCase() === decodeURIComponent(titleSlug)
+  );
+
+  if (!blog) return notFound();
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": blog.title,
+    "image": `https://www.cratonik.com${blog.image}`,
+    "author": {
+      "@type": "Person",
+      "name": blog.author
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Toolich",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://toolich.com/icon-192.svg"
+      }
+    },
+    "datePublished": blog.createdAt,
+    "description": blog.para1,
+  };
+
+  return (
+    <>
+      <div className="min-h-[calc(100vh-80px)] bg-zinc-50 dark:bg-zinc-950 pt-20 pb-12">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <Link 
+          href="/blogs" 
+          className="inline-flex items-center gap-2 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-8 transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to blogs
+        </Link>
+        
+        <article>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+          <header className="mb-10 text-center">
+            <h1 className="text-3xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-50 sm:text-4xl mb-4">
+              {blog.title}
+            </h1>
+            <div className="flex items-center justify-center text-sm text-zinc-500 dark:text-zinc-400">
+              <span>{new Date(blog.createdAt).toLocaleDateString()}</span>
+              <span className="mx-2">•</span>
+              <span>{blog.author}</span>
+            </div>
+          </header>
+          
+          <div className="mb-10 aspect-[16/9] w-full overflow-hidden rounded-2xl bg-zinc-100 dark:bg-zinc-800 shadow-md">
+            <img 
+              src={`https://www.cratonik.com${blog.image}`} 
+              alt={blog.title} 
+              className="h-full w-full object-cover object-center"
+            />
+          </div>
+          
+          <div className="prose prose-zinc dark:prose-invert max-w-none text-zinc-700 dark:text-zinc-300">
+            <p className="text-lg leading-relaxed mb-6 font-medium text-zinc-900 dark:text-zinc-100">
+              {blog.para1}
+            </p>
+            {blog.para2 && <p className="leading-relaxed mb-6">{blog.para2}</p>}
+            {blog.para3 && <p className="leading-relaxed mb-6">{blog.para3}</p>}
+          </div>
+        </article>
+      </div>
+    </div>
+    <Footer />
+    <StaticFloatingDock />
+    </>
+  );
+}

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link';
+import { Metadata } from 'next';
+import { ArrowLeft } from 'lucide-react';
+import Footer from '@/components/Footer';
+import { StaticFloatingDock } from "@/components/StaticFloatingDock";
+
+export const metadata: Metadata = {
+  title: 'Blog | Toolich',
+  description: 'Read the latest tutorials, updates, and developer guides from Toolich.',
+  openGraph: {
+    title: 'Blog | Toolich',
+    description: 'Read the latest tutorials, updates, and developer guides from Toolich.',
+    url: 'https://toolich.com/blogs',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Blog | Toolich',
+    description: 'Read the latest tutorials, updates, and developer guides from Toolich.',
+  }
+};
+
+export default async function BlogsPage() {
+  const res = await fetch('https://www.cratonik.com/api/blog', { next: { revalidate: 3600 } });
+  
+  if (!res.ok) {
+    return (
+      <div className="min-h-screen bg-zinc-50 pt-20 dark:bg-zinc-950">
+        <div className="p-8 text-center text-zinc-500">Failed to load blogs.</div>
+      </div>
+    );
+  }
+  
+  const blogs = await res.json();
+
+  return (
+    <>
+      <div className="min-h-[calc(100vh-80px)] bg-zinc-50 dark:bg-zinc-950 pt-20 pb-12">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-2 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-8 transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to home
+          </Link>
+          <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 mb-8">
+            Blog
+          </h1>
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {blogs.map((blog: any) => {
+            const slug = encodeURIComponent(blog.title.replace(/\s+/g, '-').toLowerCase());
+            return (
+              <Link 
+                key={blog.id} 
+                href={`/blogs/${slug}`} 
+                className="group flex flex-col rounded-2xl border border-zinc-200 bg-white shadow-sm transition-all hover:border-indigo-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-500/50"
+              >
+                <div className="aspect-[16/9] w-full overflow-hidden rounded-t-2xl bg-zinc-100 dark:bg-zinc-800">
+                  <img 
+                    src={`https://www.cratonik.com${blog.image}`} 
+                    alt={blog.title} 
+                    className="h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
+                  />
+                </div>
+                <div className="flex flex-1 flex-col p-5">
+                  <div className="mb-2 flex items-center text-xs text-zinc-500 dark:text-zinc-400">
+                    <span>{new Date(blog.createdAt).toLocaleDateString()}</span>
+                    <span className="mx-2">•</span>
+                    <span>{blog.author}</span>
+                  </div>
+                  <h2 className="mb-3 text-lg font-semibold leading-snug text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
+                    {blog.title}
+                  </h2>
+                  <p className="line-clamp-3 text-sm text-zinc-600 dark:text-zinc-400">
+                    {blog.para1}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+          </div>
+        </div>
+      <Footer />
+      <StaticFloatingDock />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from "next";
 import { allTools } from "@/lib/tool-registry";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const baseUrl = "https://toolich.com";
 
     // 1. Static base pages
@@ -55,5 +55,35 @@ export default function sitemap(): MetadataRoute.Sitemap {
         priority: 0.8,
     }));
 
-    return [...staticPages, ...categoryPages, ...toolPages];
+    // 4. Blog pages
+    let blogPages: MetadataRoute.Sitemap = [];
+    try {
+        const res = await fetch('https://www.cratonik.com/api/blog', { next: { revalidate: 3600 } });
+        if (res.ok) {
+            const blogs = await res.json();
+            
+            // Add the main /blogs page
+            blogPages.push({
+                url: `${baseUrl}/blogs`,
+                lastModified: blogs.length > 0 ? new Date(blogs[0].createdAt) : new Date(),
+                changeFrequency: "weekly" as const,
+                priority: 0.9,
+            });
+
+            // Add individual blogs
+            for (const blog of blogs) {
+                const slug = encodeURIComponent(blog.title.replace(/\s+/g, '-').toLowerCase());
+                blogPages.push({
+                    url: `${baseUrl}/blogs/${slug}`,
+                    lastModified: new Date(blog.createdAt),
+                    changeFrequency: "monthly" as const,
+                    priority: 0.8,
+                });
+            }
+        }
+    } catch (e) {
+        console.error("Failed to fetch blogs for sitemap", e);
+    }
+
+    return [...staticPages, ...categoryPages, ...toolPages, ...blogPages];
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,6 +26,12 @@ export default function Footer() {
                 </div>
                 <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                     <Link
+                        href="/blogs"
+                        className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-200"
+                    >
+                        Blog
+                    </Link>
+                    <Link
                         href="/about"
                         className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-200"
                     >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { SearchTrigger, SearchModal } from "./SpotlightSearch";
 import { ThemeToggle } from "./ThemeToggle";
 import { GlobalTasksPopover } from "./GlobalTasksPopover";
@@ -16,6 +17,7 @@ export default function Header({
   githubUrl = "https://github.com/cratonik/toolich",
 }: HeaderProps) {
   const { isWide, goHome } = useTabContext();
+  const pathname = usePathname();
 
   return (
     <>
@@ -24,8 +26,10 @@ export default function Header({
           <Link
             href="/"
             onClick={(e) => {
-              e.preventDefault();
-              goHome();
+              if (pathname === "/") {
+                e.preventDefault();
+                goHome();
+              }
             }}
             className="flex items-center gap-2.5 text-zinc-900 no-underline transition-opacity hover:opacity-80 dark:text-zinc-50"
             aria-label="Toolich – Home"


### PR DESCRIPTION
Closes #137

### Detailed Explanation
This PR integrates the Cratonik blogs API directly into Toolich as Server Components. This is a strategic move to provide `valuable inventory` for AdSense approvals (which often rejects single-page tools) and to significantly boost organic SEO through long-form content.

### Implementation Checkpoints
- [x] **API Integration:** Created robust fetch logic for `https://www.cratonik.com/api/blog`.
- [x] **Blog Feed (`/blogs`):** Implemented a responsive grid layout displaying all blogs, dates, and authors.
- [x] **Individual Blogs (`/blogs/[slug]`):** Implemented full article parsing and dynamic slug routing.
- [x] **SEO - XML Sitemap:** Updated `src/app/sitemap.ts` to dynamically fetch and inject all blog URLs into the root `sitemap.xml`.
- [x] **SEO - JSON-LD:** Injected Schema.org `BlogPosting` structured data to enable Rich Snippets in Google Search.
- [x] **SEO - Metadata:** Added OpenGraph and Twitter Cards for rich social unfurling.
- [x] **UI/UX:** Added the Blog navigation link to the Footer (decluttering the Header), and included the `StaticFloatingDock` on blog pages for Chatbot support.