### PR TITLE
Fix notepad visual line numbers and scrolling

### DIFF
--- a/src/tools/managers/notepad/Notepad.tsx
+++ b/src/tools/managers/notepad/Notepad.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
-import { Copy, Check, Trash2, Download, Search, Maximize2, Minimize2, Type, WrapText, AlignLeft, ArrowLeftRight } from "lucide-react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import { Copy, Check, Trash2, Download, Search, Maximize2, Minimize2, Type, WrapText, AlignLeft, ArrowLeftRight, ListOrdered } from "lucide-react";
 import { useSessionState } from "@/lib/use-session-state";
+import { useTheme } from "@/lib/theme-context";
 
 export default function Notepad() {
+    const { resolvedTheme } = useTheme();
+    
     // Basic state
     const [text, setText] = useSessionState("notepad:text", "");
     const [copied, setCopied] = useState(false);
@@ -13,19 +16,64 @@ export default function Notepad() {
     const [fontFamily, setFontFamily] = useSessionState<"mono" | "sans">("notepad:font", "mono");
     const [fontSize, setFontSize] = useSessionState<"text-sm" | "text-base" | "text-lg" | "text-xl">("notepad:size", "text-sm");
     const [wordWrap, setWordWrap] = useSessionState<boolean>("notepad:wrap", true);
+    const [showLineNumbers, setShowLineNumbers] = useSessionState<boolean>("notepad:numbers", true);
     
     // UI state
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [isWide, setIsWide] = useSessionState<boolean>("notepad:wide", false);
-    const [showSearch, setShowSearch] = useState(false);
     const [dragActive, setDragActive] = useState(false);
+    const [showSearch, setShowSearch] = useState(false);
     
     // Search state
     const [findText, setFindText] = useState("");
     const [replaceText, setReplaceText] = useState("");
     
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const [visualLines, setVisualLines] = useState(1);
+    
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const gutterRef = useRef<HTMLDivElement>(null);
+    const measureRef = useRef<HTMLDivElement>(null);
+
+    // Calculate exact number of visual lines by temporarily measuring the textarea's true scroll height
+    const updateLineCount = useCallback(() => {
+        if (!textareaRef.current || !measureRef.current) return;
+        
+        const textarea = textareaRef.current;
+        const measure = measureRef.current;
+        const lineHeight = measure.clientHeight;
+        
+        if (lineHeight === 0) return;
+
+        const scrollTop = textarea.scrollTop;
+        const oldHeight = textarea.style.height;
+        
+        // Temporarily collapse to 0 to force scrollHeight to represent ONLY the text content
+        textarea.style.height = '0px';
+        const trueScrollHeight = textarea.scrollHeight;
+        
+        // Restore immediately
+        textarea.style.height = oldHeight;
+        textarea.scrollTop = scrollTop;
+        
+        // py-4 adds 1rem (16px) top and bottom padding = 32px total
+        const paddingY = 32;
+        const textHeight = trueScrollHeight - paddingY;
+        
+        // Number of visual lines is the height divided by exact line height
+        const lines = Math.max(1, Math.round(textHeight / lineHeight));
+        setVisualLines(lines);
+    }, []);
+
+    // Update lines whenever layout-affecting state changes
+    useEffect(() => {
+        updateLineCount();
+        
+        // Observe window resize as it affects word wrapping
+        window.addEventListener('resize', updateLineCount);
+        
+        return () => window.removeEventListener('resize', updateLineCount);
+    }, [text, fontSize, fontFamily, wordWrap, isWide, isFullscreen, updateLineCount]);
 
     // Actions
     const handleCopy = async () => {
@@ -73,44 +121,47 @@ export default function Notepad() {
         [handleFile],
     );
 
-    // Search and Replace
+    // Cycle through font sizes
+    const cycleFontSize = () => {
+        const sizes: typeof fontSize[] = ["text-sm", "text-base", "text-lg", "text-xl"];
+        const currentIndex = sizes.indexOf(fontSize);
+        setFontSize(sizes[(currentIndex + 1) % sizes.length]);
+    };
+
+    // Find and Replace logic
     const handleFindNext = () => {
-        if (!findText || !textareaRef.current) return;
-        
+        if (!textareaRef.current || !findText) return;
         const textarea = textareaRef.current;
-        const startIndex = textarea.selectionEnd; // Start from current cursor
-        const index = text.toLowerCase().indexOf(findText.toLowerCase(), startIndex);
+        const content = textarea.value;
+        const searchIndex = content.toLowerCase().indexOf(findText.toLowerCase(), textarea.selectionEnd);
         
-        if (index !== -1) {
+        if (searchIndex !== -1) {
             textarea.focus();
-            textarea.setSelectionRange(index, index + findText.length);
+            textarea.setSelectionRange(searchIndex, searchIndex + findText.length);
         } else {
-            // Loop back to start
-            const firstIndex = text.toLowerCase().indexOf(findText.toLowerCase(), 0);
+            // Wrap around
+            const firstIndex = content.toLowerCase().indexOf(findText.toLowerCase());
             if (firstIndex !== -1) {
                 textarea.focus();
                 textarea.setSelectionRange(firstIndex, firstIndex + findText.length);
-            } else {
-                alert("Text not found");
             }
         }
     };
 
     const handleReplace = () => {
-        if (!findText || !textareaRef.current) return;
-        
+        if (!textareaRef.current || !findText) return;
         const textarea = textareaRef.current;
         const start = textarea.selectionStart;
         const end = textarea.selectionEnd;
-        
-        if (start !== end && text.substring(start, end).toLowerCase() === findText.toLowerCase()) {
+
+        if (start !== end && textarea.value.substring(start, end).toLowerCase() === findText.toLowerCase()) {
             const newText = text.substring(0, start) + replaceText + text.substring(end);
             setText(newText);
             
-            // Wait for render, then select the new text and find next
             setTimeout(() => {
                 if (textareaRef.current) {
-                    textareaRef.current.setSelectionRange(start, start + replaceText.length);
+                    textareaRef.current.setSelectionRange(start + replaceText.length, start + replaceText.length);
+                    handleFindNext();
                 }
             }, 0);
         } else {
@@ -120,29 +171,28 @@ export default function Notepad() {
 
     const handleReplaceAll = () => {
         if (!findText) return;
-        
-        // Escape find text for regex
-        const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex = new RegExp(escapeRegExp(findText), 'gi');
-        
-        const newText = text.replace(regex, replaceText);
-        setText(newText);
-    };
-
-    // Cycle through font sizes
-    const cycleFontSize = () => {
-        const sizes: typeof fontSize[] = ["text-sm", "text-base", "text-lg", "text-xl"];
-        const currentIndex = sizes.indexOf(fontSize);
-        setFontSize(sizes[(currentIndex + 1) % sizes.length]);
+        // Simple case-insensitive replace all
+        const regex = new RegExp(findText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+        setText(text.replace(regex, replaceText));
     };
 
     // Calculate stats
     const charCount = text.length;
     const wordCount = text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
-    const lineCount = text.split("\n").length;
-
+    // We still show logical lines in the stats footer to be accurate to file structure
+    const logicalLineCount = text.split("\n").length;
+    
     const content = (
-        <div className={`space-y-4 ${isFullscreen ? "h-full flex flex-col" : ""}`}>
+        <div className={`space-y-4 ${isFullscreen ? "flex-1 flex flex-col min-h-0" : ""}`}>
+            {/* Hidden measure element to get exact line height in pixels */}
+            <div 
+                ref={measureRef}
+                className={`absolute invisible pointer-events-none ${fontFamily === "mono" ? "font-mono" : "font-sans"} ${fontSize}`}
+                style={{ lineHeight: "1.5" }}
+            >
+                &nbsp;
+            </div>
+
             {/* Toolbar */}
             <div className="flex flex-wrap items-center justify-between gap-3 bg-zinc-50 dark:bg-zinc-900/50 p-2 rounded-xl border border-zinc-200 dark:border-zinc-800">
                 <div className="flex flex-wrap items-center gap-2">
@@ -178,7 +228,6 @@ export default function Notepad() {
                             onChange={(e) => {
                                 const file = e.target.files?.[0];
                                 if (file) handleFile(file);
-                                // reset input so same file can be loaded again
                                 if (e.target) e.target.value = '';
                             }}
                         />
@@ -198,7 +247,7 @@ export default function Notepad() {
                     <button
                         type="button"
                         onClick={() => setShowSearch(!showSearch)}
-                        className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${showSearch ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-400' : 'text-zinc-600 hover:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800'}`}
+                        className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${showSearch ? 'bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200' : 'text-zinc-600 hover:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800'}`}
                         title="Search and Replace"
                     >
                         <Search className="h-3.5 w-3.5" />
@@ -221,6 +270,15 @@ export default function Notepad() {
                     >
                         <AlignLeft className="h-3.5 w-3.5" />
                         Size
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setShowLineNumbers(!showLineNumbers)}
+                        className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${showLineNumbers ? 'bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200' : 'text-zinc-600 hover:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800'}`}
+                        title="Toggle Line Numbers"
+                    >
+                        <ListOrdered className="h-3.5 w-3.5" />
+                        Numbers
                     </button>
                     <button
                         type="button"
@@ -282,7 +340,10 @@ export default function Notepad() {
 
             {/* Editor Area */}
             <div 
-                className={`relative group ${isFullscreen ? "flex-1 flex flex-col" : ""}`}
+                className={`relative group flex ${isFullscreen ? "flex-1 min-h-0" : "h-[500px]"} rounded-xl border transition-colors shadow-sm overflow-hidden
+                    ${dragActive ? "border-indigo-500 bg-indigo-50/50 dark:border-indigo-400 dark:bg-indigo-500/10" : "border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900/60"}
+                    focus-within:border-indigo-400 focus-within:ring-2 focus-within:ring-indigo-500/20 dark:focus-within:border-indigo-500
+                `}
                 onDragOver={(e) => {
                     e.preventDefault();
                     setDragActive(true);
@@ -290,19 +351,42 @@ export default function Notepad() {
                 onDragLeave={() => setDragActive(false)}
                 onDrop={handleDrop}
             >
+                {/* Gutter */}
+                {showLineNumbers && (
+                    <div 
+                        ref={gutterRef}
+                        className={`shrink-0 overflow-hidden text-right py-4 pl-3 pr-2 select-none border-r border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-900/30 text-zinc-400 dark:text-zinc-500
+                            ${fontFamily === "mono" ? "font-mono" : "font-sans"} ${fontSize}`}
+                        style={{ 
+                            lineHeight: "1.5",
+                            minWidth: `calc(${Math.max(3, visualLines.toString().length)}ch + 1.25rem)`
+                        }}
+                    >
+                        {Array.from({ length: visualLines }, (_, i) => (
+                            <div key={i}>{i + 1}</div>
+                        ))}
+                    </div>
+                )}
+                
+                {/* Interactive Textarea Layer */}
                 <textarea
                     ref={textareaRef}
                     value={text}
                     onChange={(e) => setText(e.target.value)}
+                    onScroll={(e) => {
+                        if (gutterRef.current) {
+                            gutterRef.current.scrollTop = e.currentTarget.scrollTop;
+                        }
+                    }}
+                    wrap={wordWrap ? "soft" : "off"}
+                    spellCheck={false}
                     placeholder="Type your notes here, or drag and drop a text file..."
-                    className={`w-full ${isFullscreen ? "flex-1 h-full min-h-0 resize-none" : "min-h-[500px] resize-y"} rounded-xl border p-4 outline-none transition-colors shadow-sm
-                        ${dragActive ? "border-indigo-500 bg-indigo-50/50 dark:border-indigo-400 dark:bg-indigo-500/10" : "border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900/60"}
+                    className={`flex-1 min-h-0 overflow-y-auto w-full h-full resize-none px-4 py-4 outline-none bg-transparent border-0 focus:ring-0
                         text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-500
-                        focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/20 dark:focus:border-indigo-500
-                        ${fontFamily === "mono" ? "font-mono" : "font-sans"}
-                        ${fontSize}
-                        ${wordWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre overflow-x-auto"}
+                        ${fontFamily === "mono" ? "font-mono" : "font-sans"} ${fontSize}
+                        ${wordWrap ? "whitespace-pre-wrap break-words overflow-x-hidden" : "whitespace-pre overflow-x-auto"}
                     `}
+                    style={{ lineHeight: "1.5" }}
                 />
                 
                 {dragActive && (
@@ -319,15 +403,16 @@ export default function Notepad() {
             <div className="flex gap-4 text-xs font-medium text-zinc-500 dark:text-zinc-400">
                 <span>{charCount} characters</span>
                 <span>{wordCount} words</span>
-                <span>{lineCount} lines</span>
+                <span>{logicalLineCount} logical lines</span>
+                {showLineNumbers && <span>{visualLines} visual lines</span>}
             </div>
         </div>
     );
 
     if (isFullscreen) {
         return (
-            <div className="fixed inset-0 z-[100] bg-white dark:bg-zinc-950 p-4 md:p-8 flex flex-col h-screen overflow-hidden">
-                <div className={`mx-auto flex-1 flex flex-col w-full transition-all duration-300 ${isWide ? "max-w-none" : "max-w-5xl"}`}>
+            <div className="fixed inset-0 z-[100] bg-zinc-50 dark:bg-zinc-950 p-4 md:p-8 flex flex-col h-screen overflow-hidden">
+                <div className={`mx-auto flex-1 min-h-0 flex flex-col w-full transition-all duration-300 ${isWide ? "max-w-none" : "max-w-5xl"}`}>
                     {content}
                 </div>
             </div>


### PR DESCRIPTION
Revert to raw textarea for precise visual line numbering based on scroll height. Fixed deeply nested CSS flexbox bug preventing the textarea from scrolling correctly in focus mode.